### PR TITLE
Fix as_grey functionality in vreader

### DIFF
--- a/skvideo/io/io.py
+++ b/skvideo/io/io.py
@@ -248,7 +248,7 @@ def vreader(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=Non
         reader = FFmpegReader(fname, inputdict=inputdict, outputdict=outputdict, verbosity=verbosity)
         for frame in reader.nextFrame():
             if as_grey:
-                yield vshape(frame[:, :, :, 0])
+                yield vshape(frame[:, :, 0])
             else:
                 yield frame
 


### PR DESCRIPTION
When using the generator, the returned value has the shape (M, N, C). An extra index (T) was being requested here, but this dimension is already being iterated over.