### PR TITLE
2 bugfixes in ffmpeg process termination in vreader

### DIFF
--- a/skvideo/io/ffmpeg.py
+++ b/skvideo/io/ffmpeg.py
@@ -214,9 +214,12 @@ class FFmpegReader():
            
         return self.inputframenum, self.outputheight, self.outputwidth, self.outputdepth
 
-
     def close(self):
-        self._terminate(0.05)  # Short timeout
+        if self._proc is not None and self._proc.poll() is None:
+            self._proc.stdin.close()
+            self._proc.stdout.close()
+            self._proc.stderr.close()
+            self._terminate(0.2)
         self._proc = None
 
     def _terminate(self, timeout=1.0):

--- a/skvideo/io/io.py
+++ b/skvideo/io/io.py
@@ -249,12 +249,14 @@ def vreader(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=Non
             outputdict['-pix_fmt'] = 'gray'
 
         reader = FFmpegReader(fname, inputdict=inputdict, outputdict=outputdict, verbosity=verbosity)
-        for frame in reader.nextFrame():
-            if as_grey:
-                yield vshape(frame[:, :, 0])
-            else:
-                yield frame
-        reader.close()
+        try:
+            for frame in reader.nextFrame():
+                if as_grey:
+                    yield vshape(frame[:, :, 0])
+                else:
+                    yield frame
+        finally:
+            reader.close()
 
     elif backend == "libav":
         # check if FFMPEG exists in the path
@@ -267,9 +269,11 @@ def vreader(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=Non
             outputdict['-vframes'] = str(num_frames)
 
         reader = LibAVReader(fname, inputdict=inputdict, outputdict=outputdict, verbosity=verbosity)
-        for frame in reader.nextFrame():
-            yield frame
-        reader.close()
+        try:
+            for frame in reader.nextFrame():
+                yield frame
+        finally:
+            reader.close()
 
     else:
         raise NotImplemented


### PR DESCRIPTION
1. Added explicit closing of `stdin`, `stdout` and `stderr` for `subprocess.Popen` - otherwise there remain zombie ffmpeg processes that quickly devour all the memory if you try to read many videos. 

2. When using `skvideo.io.vreader` yielding the next frame sometimes leads to exceptions. In that case `reader.close()` method call was never even reached, again leading to zombie ffmpeg processes. Fixed this by wrapping with `try`-`finally`.