### PR TITLE
Substitute fromstring (deprecated method) by frombuffer

### DIFF
--- a/skvideo/io/ffmpeg.py
+++ b/skvideo/io/ffmpeg.py
@@ -274,7 +274,7 @@ class FFmpegReader():
 
         try:
             # Read framesize bytes
-            arr = np.fromstring(self._proc.stdout.read(framesize), dtype=np.uint8)
+            arr = np.frombuffer(self._proc.stdout.read(framesize), dtype=np.uint8)
             assert len(arr) == framesize
         except Exception as err:
             self._terminate()
@@ -286,7 +286,7 @@ class FFmpegReader():
         # Read and convert to numpy array
         # t0 = time.time()
         s = self._read_frame_data()
-        result = np.fromstring(s, dtype='uint8')
+        result = np.frombuffer(s, dtype='uint8')
 
         result = result.reshape((self.outputheight, self.outputwidth, self.outputdepth))
 


### PR DESCRIPTION
When running skvideo.io.vreader the following warning pops up:

~~~~
/usr/local/lib/python3.6/dist-packages/skvideo/io/ffmpeg.py:270: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
  arr = np.fromstring(self._proc.stdout.read(framesize), dtype=np.uint8)

/usr/local/lib/python3.6/dist-packages/skvideo/io/ffmpeg.py:282: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
  result = np.fromstring(s, dtype='uint8')
~~~~

So every call to np.fromstring should be substituted.

I'm running with Python 3.6.3 but the issue seems to be Numpy's.