### PR TITLE
Fix travis builds for Python 2.6 in OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,6 @@ matrix:
         COVERAGE="true"
     include:
         - os: osx
-          python: "3.5"
-          osx_image: xcode8.2
-          env: TRAVIS_PYTHON_VERSION=3.5 FFMPEG=2.8 LIBAV=none
-        - os: osx
-          python: "3.5"
-          osx_image: xcode8.2
-          env: TRAVIS_PYTHON_VERSION=3.5 FFMPEG=snapshot LIBAV=none
-        - os: osx
           python: "2.6"
           osx_image: xcode8.2
           env: TRAVIS_PYTHON_VERSION=2.6 FFMPEG=2.8 LIBAV=none
@@ -24,30 +16,6 @@ matrix:
           python: "2.6"
           osx_image: xcode8.2
           env: TRAVIS_PYTHON_VERSION=2.6 FFMPEG=snapshot LIBAV=none
-        - os: osx
-          python: "2.7"
-          osx_image: xcode8.2
-          env: TRAVIS_PYTHON_VERSION=2.7 FFMPEG=2.8 LIBAV=none
-        - os: osx
-          osx_image: xcode8.2
-          python: "2.7"
-          env: TRAVIS_PYTHON_VERSION=2.7 FFMPEG=snapshot LIBAV=none
-        - os: linux
-          python: "3.5"
-          language: python
-          env: FFMPEG=2.8 LIBAV=11.4
-        - os: linux
-          python: "3.5"
-          language: python
-          env: FFMPEG=snapshot LIBAV=none
-        - os: linux
-          python: "2.7"
-          language: python
-          env: FFMPEG=2.8 LIBAV=11.4
-        - os: linux
-          python: "2.7"
-          language: python
-          env: FFMPEG=snapshot LIBAV=none
         - os: linux
           python: "2.6"
           language: python

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,8 +2,8 @@ conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib nose co
 
 echo $TRAVIS_PYTHON_VERSION
 if [[ "$TRAVIS_PYTHON_VERSION" == "2.6" ]]; then
-	conda install --yes python=$TRAVIS_PYTHON_VERSION unittest2 scipy=0.14.0
-  pip install -I pillow==3.4.2
+	conda install --yes python=$TRAVIS_PYTHON_VERSION unittest2 scipy==0.16.0
+    pip install -I pillow==3.4.2
 fi
 
 GIT_TRAVIS_REPO=$(pwd)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,8 +2,8 @@ conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib nose co
 
 echo $TRAVIS_PYTHON_VERSION
 if [[ "$TRAVIS_PYTHON_VERSION" == "2.6" ]]; then
-	conda install --yes python=$TRAVIS_PYTHON_VERSION unittest2 scipy=0.16.0
-    pip install -I pillow==3.4.2
+	conda install --yes python=$TRAVIS_PYTHON_VERSION unittest2 scipy=0.14.0
+    pip install -I pillow==4.0.0
 fi
 
 GIT_TRAVIS_REPO=$(pwd)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,8 +2,8 @@ conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib nose co
 
 echo $TRAVIS_PYTHON_VERSION
 if [[ "$TRAVIS_PYTHON_VERSION" == "2.6" ]]; then
-	conda install --yes python=$TRAVIS_PYTHON_VERSION unittest2 scipy=0.14.0
-  pip install -I pillow==3.4.2
+	conda install --yes python=$TRAVIS_PYTHON_VERSION unittest2
+    pip install -I pillow==3.4.2 scipy=0.14.0
 fi
 
 GIT_TRAVIS_REPO=$(pwd)


### PR DESCRIPTION
Travis builds in OSX for Python 2.6 are failing.

~~~~
img2 = scipy.misc.imresize(img, 0.5, interp='bicubic', mode='F')
AttributeError: 'module' object has no attribute 'imresize'
~~~~