### PR TITLE
fix bugs in Block-based motion compensation when using Python 3

### DIFF
--- a/skvideo/measure/msssim.py
+++ b/skvideo/measure/msssim.py
@@ -91,7 +91,7 @@ def msssim(referenceVideoData, distortedVideoData, method='product'):
     T, M, N, C = referenceVideoData.shape
 
     assert C == 1, "MS-SSIM called with videos containing %d channels. Please supply only the luminance channel" % (C,)
-    assert (M >= 176) | (N >= 176), "You supplied a resolution of %dx%d. MS-SSIM can only be used with videos large enough having multiple scales. Please use only with resolutions >= 176x176." % (M, N)
+    assert (M >= 176) & (N >= 176), "You supplied a resolution of %dx%d. MS-SSIM can only be used with videos large enough having multiple scales. Please use only with resolutions >= 176x176." % (M, N)
 
     scores = np.zeros(T, dtype=np.float32)
     for t in range(T):

--- a/skvideo/motion/block.py
+++ b/skvideo/motion/block.py
@@ -638,8 +638,8 @@ def _N3SS(imgP, imgI, mbSize, p):
                                (refBlkHor < 0) or
                                (refBlkHor + mbSize > w)):
                                     continue
-                            costRow = m/stepSize + 1
-                            costCol = n/stepSize + 1
+                            costRow = np.int(m / stepSize) + 1
+                            costCol = np.int(n / stepSize) + 1
                             if ((costRow == 1) and (costCol == 1)):
                                 continue
                             costs[costRow, costCol] = _costMAD(imgP[i:i + mbSize, j:j + mbSize], imgI[refBlkVer:refBlkVer + mbSize, refBlkHor:refBlkHor + mbSize])

--- a/skvideo/motion/block.py
+++ b/skvideo/motion/block.py
@@ -990,8 +990,8 @@ def _subcomp(framedata, motionVect, mbSize):
 
     for i in range(0, M - mbSize + 1, mbSize):
         for j in range(0, N - mbSize + 1, mbSize):
-            dy = motionVect[i / mbSize, j / mbSize, 0]
-            dx = motionVect[i / mbSize, j / mbSize, 1]
+            dy = motionVect[np.int(i / mbSize), np.int(j / mbSize), 0]
+            dx = motionVect[np.int(i / mbSize), np.int(j / mbSize), 1]
 
             refBlkVer = i + dy
             refBlkHor = j + dx

--- a/skvideo/motion/block.py
+++ b/skvideo/motion/block.py
@@ -488,7 +488,7 @@ def _SE3SS(imgP, imgI, mbSize, p):
                     y = refBlkVerPointF
 
                 costs[:] = 65537
-                stepSize /= 2
+                stepSize = np.int(stepSize / 2)
 
             vectors[np.int(i / mbSize), np.int(j / mbSize), :] = [y - i, x - j]
 
@@ -627,7 +627,7 @@ def _N3SS(imgP, imgI, mbSize, p):
             elif NTSSFlag == 0:
                 costs[:, :] = 65537
                 costs[1, 1] = min1
-                stepSize = stepMax / 2
+                stepSize = np.int(stepMax / 2)
                 while(stepSize >= 1):
                     for m in range(-stepSize, stepSize+1, stepSize):
                         for n in range(-stepSize, stepSize+1, stepSize):
@@ -649,7 +649,7 @@ def _N3SS(imgP, imgI, mbSize, p):
                     x += (dx - 1) * stepSize
                     y += (dy - 1) * stepSize
 
-                    stepSize /= 2
+                    stepSize = np.int(stepSize / 2)
                     costs[1, 1] = costs[dy, dx]
 
 
@@ -702,7 +702,7 @@ def _3SS(imgP, imgI, mbSize, p):
                 x += (dx - 1) * stepSize
                 y += (dy - 1) * stepSize
 
-                stepSize /= 2
+                stepSize = np.int(stepSize / 2)
                 costs[1, 1] = costs[dy, dx]
             vectors[np.int(i / mbSize), np.int(j / mbSize), :] = [y - i, x - j]
 


### PR DESCRIPTION
line 993-994, _subcomp in Block-based motion compensation

`dy = motionVect[np.int(i / mbSize), np.int(j / mbSize), 0]`
`dx = motionVect[np.int(i / mbSize), np.int(j / mbSize), 1]`