### PR TITLE
fix one bug and make some improvements

### DIFF
--- a/skvideo/measure/Li3DDCT.py
+++ b/skvideo/measure/Li3DDCT.py
@@ -34,7 +34,7 @@ def Li3DDCT_features(videoData):
     T, M, N, C = videoData.shape
 
     assert C == 1, "called with video having %d channels. Please supply only the luminance channel." % (C,)
-    assert T >= 4, "Not enough input frames. Please supply at least 4" % (C,)
+    assert T >= 4, "Only %d input frames. Please supply at least 4" % (T,)
 
     feats = np.zeros((63*5,), dtype=np.float32)
     newM = np.int32(np.floor(M/4)*4)

--- a/skvideo/measure/__init__.py
+++ b/skvideo/measure/__init__.py
@@ -7,7 +7,7 @@ from .ssim import *
 from .strred import *
 from .psnr import *
 from .mse import *
-from .mad import *
+from .mae import *
 from .scene import *
 from .brisque import *
 from .videobliinds import *
@@ -20,7 +20,7 @@ __all__ = [
     'ssim',
     'strred',
     'mse',
-    'mad',
+    'mae',
     'psnr',
     'scenedet',
     'brisque_features',

--- a/skvideo/measure/mae.py
+++ b/skvideo/measure/mae.py
@@ -3,11 +3,11 @@ import numpy as np
 import scipy.ndimage
 
 
-def mad(referenceVideoData, distortedVideoData):
-    """Computes mean absolute deviation (MAD).
+def mae(referenceVideoData, distortedVideoData):
+    """Computes mean absolute error (MAE).
 
     Both video inputs are compared frame-by-frame to obtain T
-    MAD measurements.
+    MAE measurements.
 
     Parameters
     ----------
@@ -23,8 +23,8 @@ def mad(referenceVideoData, distortedVideoData):
 
     Returns
     -------
-    mad_array : ndarray
-        The mad results, ndarray of dimension (T,), where T
+    mae_array : ndarray
+        The mae results, ndarray of dimension (T,), where T
         is the number of frames
 
     """
@@ -36,15 +36,15 @@ def mad(referenceVideoData, distortedVideoData):
 
     T, M, N, C = referenceVideoData.shape
 
-    assert C == 1, "mad called with videos containing %d channels. Please supply only the luminance channel" % (C,)
+    assert C == 1, "mae called with videos containing %d channels. Please supply only the luminance channel" % (C,)
 
     scores = np.zeros(T, dtype=np.float32)
     for t in range(T):
         referenceFrame = referenceVideoData[t].astype(np.float32)
         distortedFrame = distortedVideoData[t].astype(np.float32)
 
-        mad = np.mean(np.abs(referenceFrame - distortedFrame))
+        mae = np.mean(np.abs(referenceFrame - distortedFrame))
 
-        scores[t] = mad
+        scores[t] = mae
 
     return scores

--- a/skvideo/motion/gme.py
+++ b/skvideo/motion/gme.py
@@ -60,16 +60,15 @@ def globalEdgeMotion(frame1, frame2, r=6, method='hamming'):
 
     """
 
-    # if type bool, then these are edge maps. No need to convert them
     frame1 = vshape(frame1)
     frame2 = vshape(frame2)
-    if frame1.shape[3] == 3:
-        frame1 = rgb2gray(frame1)
-    if frame2.shape[3] == 3:
-        frame2 = rgb2gray(frame2)
-    frame1 = frame1[0, ..., 0]
-    frame2 = frame2[0, ..., 0]
+    
+    assert(frame1.shape == frame2.shape)
 
+    T, M, N, C = frame1.shape
+
+    assert C == 1, "called with frames having %d channels. Please supply only the luminance channel." % (C,)
+    # if type bool, then these are edge maps. No need to convert them
     if frame1.dtype != np.bool:
         E_1 = canny(frame1)
     else:

--- a/skvideo/motion/gme.py
+++ b/skvideo/motion/gme.py
@@ -61,6 +61,15 @@ def globalEdgeMotion(frame1, frame2, r=6, method='hamming'):
     """
 
     # if type bool, then these are edge maps. No need to convert them
+    frame1 = vshape(frame1)
+    frame2 = vshape(frame2)
+    if frame1.shape[3] == 3:
+        frame1 = rgb2gray(frame1)
+    if frame2.shape[3] == 3:
+        frame2 = rgb2gray(frame2)
+    frame1 = frame1[0, ..., 0]
+    frame2 = frame2[0, ..., 0]
+
     if frame1.dtype != np.bool:
         E_1 = canny(frame1)
     else:

--- a/skvideo/motion/gme.py
+++ b/skvideo/motion/gme.py
@@ -16,8 +16,8 @@ def _hausdorff_distance(E_1, E_2):
     diamond = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]])
 
     # extract only 1-pixel border line of objects
-    E_1_per = E_1 - scipy.ndimage.morphology.binary_erosion(E_1, structure=diamond)
-    E_2_per = E_2 - scipy.ndimage.morphology.binary_erosion(E_2, structure=diamond)
+    E_1_per = E_1^scipy.ndimage.morphology.binary_erosion(E_1, structure=diamond)
+    E_2_per = E_2^scipy.ndimage.morphology.binary_erosion(E_2, structure=diamond)
 
     A = scipy.ndimage.morphology.distance_transform_edt(~E_2_per)[E_1_per].max()
     B = scipy.ndimage.morphology.distance_transform_edt(~E_1_per)[E_2_per].max()

--- a/skvideo/tests/test_measure.py
+++ b/skvideo/tests/test_measure.py
@@ -152,12 +152,12 @@ def test_measure_NIQE():
     assert_almost_equal(scores[1], 11.055174827576, decimal=10)
 
 
-def test_measure_MAD():
+def test_measure_MAE():
     vidpaths = skvideo.datasets.fullreferencepair()
     ref = skvideo.io.vread(vidpaths[0], as_grey=True)
     dis = skvideo.io.vread(vidpaths[1], as_grey=True)
 
-    scores = skvideo.measure.mad(ref, dis)
+    scores = skvideo.measure.mae(ref, dis)
 
     avg_score = np.mean(scores)
 


### PR DESCRIPTION
- standardizing inputs of `globalEdgeMotion` and fix bugs: numpy boolean subtract in `_hausdorff_distance`

- replacing `mad` using `mae` to avoid confusion

- applying `rgb2gray` before calculating related quality measures

- 