### PR TITLE
add numpy.uint16 support

### DIFF
--- a/skvideo/io/avconv.py
+++ b/skvideo/io/avconv.py
@@ -7,24 +7,19 @@ a wide range of video formats.
 # Copyright (c) 2015, imageio contributors
 # distributed under the terms of the BSD License (included in release).
 
-import sys
 import os
-import stat
-import re
-import time
-import threading
 import subprocess as sp
-import logging
-import json
+import time
 import warnings
 
 import numpy as np
 
 from .avprobe import avprobe
-from ..utils import *
-from .. import _HAS_AVCONV
-from .. import _AVCONV_PATH
 from .. import _AVCONV_APPLICATION
+from .. import _AVCONV_PATH
+from .. import _HAS_AVCONV
+from ..utils import *
+
 
 # uses libav to read the given file with parameters
 class LibAVReader():
@@ -171,7 +166,17 @@ class LibAVReader():
 
         self.outputdepth = np.int(bpplut[outputdict['-pix_fmt']][0])
         self.outputbpp = np.int(bpplut[outputdict['-pix_fmt']][1])
-
+        bitpercomponent = self.outputbpp // self.outputdepth
+        if bitpercomponent == 8:
+            self.dtype = np.uint8
+        elif bitpercomponent == 16:
+            suffix = outputdict['-pix_fmt'][-2:]
+            if suffix == 'le':
+                self.dtype = np.dtype('<u2')
+            elif suffix == 'be':
+                self.dtype = np.dtype('>u2')
+        else:
+            raise ValueError(outputdict['-pix_fmt'] + 'is not a valid pix_fmt for numpy conversion')
 
         # Create input args
         iargs = []
@@ -238,7 +243,7 @@ class LibAVReader():
 
         try:
             # Read framesize bytes
-            arr = np.fromstring(self._proc.stdout.read(framesize), dtype=np.uint8)
+            arr = np.frombuffer(self._proc.stdout.read(framesize * self.dtype.itemsize), dtype=self.dtype)
             assert len(arr) == framesize
         except Exception as err:
             self._terminate()
@@ -248,16 +253,8 @@ class LibAVReader():
 
     def _readFrame(self):
         # Read and convert to numpy array
-        # t0 = time.time()
-        s = self._read_frame_data()
-        result = np.fromstring(s, dtype='uint8')
-        result = result.reshape((self.outputheight, self.outputwidth, self.outputdepth))
-        # t1 = time.time()
-        # print('etime', t1-t0)
-
-        # Store and return
-        self._lastread = result
-        return result
+        self._lastread = self._read_frame_data().reshape((self.outputheight, self.outputwidth, self.outputdepth))
+        return self._lastread
 
     def nextFrame(self):
         """Yields frames using a generator 
@@ -327,31 +324,58 @@ class LibAVWriter():
 
         self.rgb2grayhack = 0
 
-    def _warmStart(self, M, N, C):
+    def _warmStart(self, M, N, C, dtype):
         self.warmStarted = 1
 
         if "-pix_fmt" not in self.inputdict:
-            # check the number channels to guess 
-            if C == 1:
-                # unfortunately, 'gray' has a bug for avconv
-                # enable gray -> rgb hack
-                self.inputdict["-pix_fmt"] = "gray"
-                self.inputdict["-pix_fmt"] = "rgb24"
-                self.rgb2grayhack = 1
-                C = 3
-            elif C == 2:
-                self.inputdict["-pix_fmt"] = "ya8"
-            elif C == 3:
-                self.inputdict["-pix_fmt"] = "rgb24"
-            elif C == 4:
-                self.inputdict["-pix_fmt"] = "rgba"
+            # check the number channels to guess
+            if dtype.kind == 'u' and dtype.itemsize == 2:
+                suffix = '<' if dtype.byteorder else '>'
+                if C == 1:
+                    # lets assume that 'gray16?e' has the same bug as 'gray' for avconv
+                    # enable gray -> rgb hack
+                    self.inputdict["-pix_fmt"] = "rgb48" + suffix
+                    self.rgb2grayhack = 1
+                    C = 3
+                elif C == 2:
+                    self.inputdict["-pix_fmt"] = "ya16" + suffix
+                elif C == 3:
+                    self.inputdict["-pix_fmt"] = "rgb48" + suffix
+                elif C == 4:
+                    self.inputdict["-pix_fmt"] = "rgba64" + suffix
+                else:
+                    raise NotImplemented
             else:
-                raise NotImplemented
+                if C == 1:
+                    # unfortunately, 'gray' has a bug for avconv
+                    # enable gray -> rgb hack
+                    self.inputdict["-pix_fmt"] = "rgb24"
+                    self.rgb2grayhack = 1
+                    C = 3
+                elif C == 2:
+                    self.inputdict["-pix_fmt"] = "ya8"
+                elif C == 3:
+                    self.inputdict["-pix_fmt"] = "rgb24"
+                elif C == 4:
+                    self.inputdict["-pix_fmt"] = "rgba"
+                else:
+                    raise NotImplemented
 
         self.bpp = bpplut[self.inputdict["-pix_fmt"]][1]
         self.inputNumChannels = bpplut[self.inputdict["-pix_fmt"]][0]
-        
-        assert self.inputNumChannels == C, "Failed to pass the correct number of channels %d for the pixel format %s." % (self.inputNumChannels, self.inputdict["-pix_fmt"])  
+        bitpercomponent = self.bpp // self.inputNumChannels
+        if bitpercomponent == 8:
+            self.dtype = np.uint8
+        elif bitpercomponent == 16:
+            suffix = self.inputdict['-pix_fmt'][-2:]
+            if suffix == 'le':
+                self.dtype = np.dtype('<u2')
+            elif suffix == 'be':
+                self.dtype = np.dtype('>u2')
+        else:
+            raise ValueError(self.inputdict['-pix_fmt'] + 'is not a valid pix_fmt for numpy conversion')
+
+        assert self.inputNumChannels == C, "Failed to pass the correct number of channels %d for the pixel format %s." % (self.inputNumChannels, self.inputdict["-pix_fmt"])
 
         if ("-s" in self.inputdict):
             widthheight = self.inputdict["-s"].split('x')
@@ -421,21 +445,18 @@ class LibAVWriter():
         vid = vshape(im)
         T, M, N, C = vid.shape
         if not self.warmStarted:
-            self._warmStart(M, N, C)
+            self._warmStart(M, N, C, im.dtype)
 
-        # Ensure that ndarray image is in uint8
-        vid[vid > 255] = 255
-        vid[vid < 0] = 0
-        vid = vid.astype(np.uint8)
+        vid = vid.clip(0, (1 << (self.dtype.itemsize << 3)) - 1).astype(self.dtype)
 
         if self.rgb2grayhack:
             # convert grayscale vid to 3 channel
-            vid2 = np.zeros((T, M, N, 3), dtype=np.uint8)
+            vid2 = np.empty((T, M, N, 3), dtype=vid.dtype)
             vid2[:, :, :, 0] = vid[:, :, :, 0]
             vid2[:, :, :, 1] = vid[:, :, :, 0]
             vid2[:, :, :, 2] = vid[:, :, :, 0]
             vid = vid2
-            T, M, N, C = vid.shape
+            C = 3
 
         # Check size of image
         if M != self.inputheight or N != self.inputwidth:

--- a/skvideo/io/ffmpeg.py
+++ b/skvideo/io/ffmpeg.py
@@ -7,26 +7,21 @@ a wide range of video formats.
 # Copyright (c) 2015, imageio contributors
 # distributed under the terms of the BSD License (included in release).
 
-import sys
 import os
-import stat
-import re
-import time
-import threading
 import subprocess as sp
-import logging
-import json
+import time
 import warnings
 
 import numpy as np
 
 from .ffprobe import ffprobe
-from ..utils import *
-from .. import _HAS_FFMPEG
+from .. import _FFMPEG_APPLICATION
 from .. import _FFMPEG_PATH
 from .. import _FFMPEG_SUPPORTED_DECODERS
 from .. import _FFMPEG_SUPPORTED_ENCODERS
-from .. import _FFMPEG_APPLICATION
+from .. import _HAS_FFMPEG
+from ..utils import *
+
 
 # uses FFmpeg to read the given file with parameters
 class FFmpegReader():
@@ -201,6 +196,17 @@ class FFmpegReader():
 
         self.outputdepth = np.int(bpplut[outputdict['-pix_fmt']][0])
         self.outputbpp = np.int(bpplut[outputdict['-pix_fmt']][1])
+        bitpercomponent = self.outputbpp//self.outputdepth
+        if bitpercomponent == 8:
+            self.dtype = np.uint8
+        elif bitpercomponent == 16:
+            suffix = outputdict['-pix_fmt'][-2:]
+            if suffix == 'le':
+                self.dtype = np.dtype('<u2')
+            elif suffix == 'be':
+                self.dtype = np.dtype('>u2')
+        else:
+            raise ValueError(outputdict['-pix_fmt'] + 'is not a valid pix_fmt for numpy conversion')
 
         if '-vcodec' not in outputdict:
             outputdict['-vcodec'] = "rawvideo"
@@ -274,7 +280,7 @@ class FFmpegReader():
 
         try:
             # Read framesize bytes
-            arr = np.frombuffer(self._proc.stdout.read(framesize), dtype=np.uint8)
+            arr = np.frombuffer(self._proc.stdout.read(framesize*self.dtype.itemsize), dtype=self.dtype)
             assert len(arr) == framesize
         except Exception as err:
             self._terminate()
@@ -284,14 +290,8 @@ class FFmpegReader():
 
     def _readFrame(self):
         # Read and convert to numpy array
-        # t0 = time.time()
-        s = self._read_frame_data()
-        result = np.frombuffer(s, dtype='uint8')
-
-        result = result.reshape((self.outputheight, self.outputwidth, self.outputdepth))
-
-        self._lastread = result
-        return result
+        self._lastread = self._read_frame_data().reshape((self.outputheight, self.outputwidth, self.outputdepth))
+        return self._lastread
 
     def nextFrame(self):
         """Yields frames using a generator 
@@ -372,24 +372,48 @@ class FFmpegWriter():
             self.inputdict["-f"] = "rawvideo"
         self.warmStarted = 0
 
-    def _warmStart(self, M, N, C):
+    def _warmStart(self, M, N, C, dtype):
         self.warmStarted = 1
 
         if "-pix_fmt" not in self.inputdict:
-            # check the number channels to guess 
-            if C == 1:
-                self.inputdict["-pix_fmt"] = "gray"
-            elif C == 2:
-                self.inputdict["-pix_fmt"] = "ya8"
-            elif C == 3:
-                self.inputdict["-pix_fmt"] = "rgb24"
-            elif C == 4:
-                self.inputdict["-pix_fmt"] = "rgba"
+            # check the number channels to guess
+            if dtype.kind == 'u' and dtype.itemsize == 2:
+                suffix = '<' if dtype.byteorder else '>'
+                if C == 1:
+                    self.inputdict["-pix_fmt"] = "gray16" + suffix
+                elif C == 2:
+                    self.inputdict["-pix_fmt"] = "ya16" + suffix
+                elif C == 3:
+                    self.inputdict["-pix_fmt"] = "rgb48" + suffix
+                elif C == 4:
+                    self.inputdict["-pix_fmt"] = "rgba64" + suffix
+                else:
+                    raise NotImplemented
             else:
-                raise NotImplemented
+                if C == 1:
+                    self.inputdict["-pix_fmt"] = "gray"
+                elif C == 2:
+                    self.inputdict["-pix_fmt"] = "ya8"
+                elif C == 3:
+                    self.inputdict["-pix_fmt"] = "rgb24"
+                elif C == 4:
+                    self.inputdict["-pix_fmt"] = "rgba"
+                else:
+                    raise NotImplemented
 
         self.bpp = bpplut[self.inputdict["-pix_fmt"]][1]
         self.inputNumChannels = bpplut[self.inputdict["-pix_fmt"]][0]
+        bitpercomponent = self.bpp // self.inputNumChannels
+        if bitpercomponent == 8:
+            self.dtype = np.uint8
+        elif bitpercomponent == 16:
+            suffix = self.inputdict['-pix_fmt'][-2:]
+            if suffix == 'le':
+                self.dtype = np.dtype('<u2')
+            elif suffix == 'be':
+                self.dtype = np.dtype('>u2')
+        else:
+            raise ValueError(self.inputdict['-pix_fmt'] + 'is not a valid pix_fmt for numpy conversion')
         
         assert self.inputNumChannels == C, "Failed to pass the correct number of channels %d for the pixel format %s." % (self.inputNumChannels, self.inputdict["-pix_fmt"])  
 
@@ -456,12 +480,9 @@ class FFmpegWriter():
         vid = vshape(im)
         T, M, N, C = vid.shape
         if not self.warmStarted:
-            self._warmStart(M, N, C)
+            self._warmStart(M, N, C, im.dtype)
 
-        # Ensure that ndarray image is in uint8
-        vid[vid > 255] = 255
-        vid[vid < 0] = 0
-        vid = vid.astype(np.uint8)
+        vid = vid.clip(0,(1<<(self.dtype.itemsize<<3))-1).astype(self.dtype)
 
         # Check size of image
         if M != self.inputheight or N != self.inputwidth:

--- a/skvideo/io/io.py
+++ b/skvideo/io/io.py
@@ -1,13 +1,13 @@
 import numpy as np
-import subprocess
-import os
-from ..utils import *
-from .ffmpeg import FFmpegReader
-from .ffmpeg import FFmpegWriter
+
 from .avconv import LibAVReader
 from .avconv import LibAVWriter
-from .. import _HAS_FFMPEG
+from .ffmpeg import FFmpegReader
+from .ffmpeg import FFmpegWriter
 from .. import _HAS_AVCONV
+from .. import _HAS_FFMPEG
+from ..utils import *
+
 
 def vwrite(fname, videodata, inputdict=None, outputdict=None, backend='ffmpeg', verbosity=0):
     """Save a video to file entirely from memory.
@@ -144,11 +144,11 @@ def vread(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=None,
         reader = FFmpegReader(fname, inputdict=inputdict, outputdict=outputdict, verbosity=verbosity)
         T, M, N, C = reader.getShape()
 
-        videodata = np.zeros((T, M, N, C), dtype=np.uint8)
+        videodata = np.empty((T, M, N, C), dtype=reader.dtype)
         for idx, frame in enumerate(reader.nextFrame()):
             videodata[idx, :, :, :] = frame
 
-        if as_grey: 
+        if as_grey:
             videodata = vshape(videodata[:, :, :, 0])
         reader.close()
 
@@ -166,7 +166,7 @@ def vread(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=None,
         reader = LibAVReader(fname, inputdict=inputdict, outputdict=outputdict, verbosity=verbosity)
         T, M, N, C = reader.getShape()
 
-        videodata = np.zeros((T, M, N, C), dtype=np.uint8)
+        videodata = np.empty((T, M, N, C), dtype=reader.dtype)
         for idx, frame in enumerate(reader.nextFrame()):
             videodata[idx, :, :, :] = frame
 


### PR DESCRIPTION
in pseudo code :

-------------------------------------------------------
for reader :
  if bpplut[pix_fmt][1]//bpplut[pix_fmt][0] == 16 :
    use dtype uint16 ('<u2' or '>u2' depending of endianess of the pix_fmt)
  else:
    do as usual

for writer :
  if pix_fmt is not set :
    if frame.dtype == uint16 ('<u2' or '>u2' in fact) :
      use a 16bit per channel format in _warmStart (taking endianess into account)
    else :
      do as usual
  else :
    if bpplut[pix_fmt][1]//bpplut[pix_fmt][0] == 16 :
    use dtype uint16 ('<u2' or '>u2' depending of endianess of the pix_fmt)
  else :
    do as usual

-------------------------------------------------------
The only backward compatibility issue would be for people using video writer with uint16 ndarray without specific input pix_fmt and using values between 0 and 255 as it would produce black videos. 
If that's a problem, a parameter 'allow16bits' which would default to false could be added in the writer __init__