### PR TITLE
Add correct reshaping for yuv444p frames

### DIFF
--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -277,8 +277,9 @@ class VideoReaderAbstract(object):
         elif self.output_pix_fmt == 'rgb24':
             self._lastread = frame.reshape((self.outputheight, self.outputwidth, self.outputdepth))
 
-        elif self.verbosity > 0:
-            warnings.warn('Unsupported reshaping from raw buffer to images frames  for format {:}. Assuming HEIGHTxWIDTHxCOLOR'.format(self.output_pix_fmt), UserWarning)
+        else:
+            if self.verbosity > 0:
+                warnings.warn('Unsupported reshaping from raw buffer to images frames  for format {:}. Assuming HEIGHTxWIDTHxCOLOR'.format(self.output_pix_fmt), UserWarning)
             self._lastread = frame.reshape((self.outputheight, self.outputwidth, self.outputdepth))
 
         return self._lastread

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -173,6 +173,7 @@ class VideoReaderAbstract(object):
 
         if '-pix_fmt' not in outputdict:
             outputdict['-pix_fmt'] = "rgb24"
+        self.output_pix_fmt = outputdict['-pix_fmt']
 
         if '-s' in outputdict:
             widthheight = outputdict["-s"].split('x')
@@ -267,7 +268,18 @@ class VideoReaderAbstract(object):
 
     def _readFrame(self):
         # Read and convert to numpy array
-        self._lastread = self._read_frame_data().reshape((self.outputheight, self.outputwidth, self.outputdepth))
+        frame = self._read_frame_data()
+
+        if self.output_pix_fmt.startswith('yuv444p'):
+            self._lastread = frame.reshape((self.outputdepth, self.outputheight, self.outputwidth)).transpose((1, 2, 0))
+
+        elif self.output_pix_fmt == 'rgb24':
+            self._lastread = frame.reshape((self.outputheight, self.outputwidth, self.outputdepth))
+
+        elif self.verbosity > 0:
+            warnings.warn('Unsupported reshaping from raw buffer to images frames  for format {:}. Assuming HEIGHTxWIDTHxCOLOR'.format(self.output_pix_fmt), UserWarning)
+            self._lastread = frame.reshape((self.outputheight, self.outputwidth, self.outputdepth))
+
         return self._lastread
 
     def nextFrame(self):


### PR DESCRIPTION
The raw buffer coming from ffmpeg was assumed to be ordered in a HEIGHTxWIDTHxCOLOR way.
This is not the case for YUV frames which are ordered in a COLORxHEIGHTxWIDTH way.
The _readFrame function from VideoReaderAbstract has been patched for yuv444p raw frames.

YUV formats with chroma subsampling do not have the same amount of pixel per each channel.
A warning message has been added for users using other pixel formats than yuv444p and rgb24.

Edit: I mixed up my commits a bit, the second `Add correct reshaping for yuv422p frames` commit is supposed to be the `Add the output_pix_fmt field to VideoReaderAbstract` commit.