### PR TITLE
Use the new setup from setuptools.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ import setuptools
 from setuptools import setup
 
 # https://packaging.python.org/guides/single-sourcing-package-version/
+import codecs
 here = os.path.abspath(os.path.dirname(__file__))
 
 def read(*parts):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ import sys
 import subprocess
 
 import setuptools
-from distutils.core import setup
+from setuptools import setup
 
 import skvideo
 

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ except ImportError:
 # Call the setup function
 if __name__ == "__main__":
     setup(configuration=configuration,
+          packages=setuptools.find_packages(),
           name=DISTNAME,
           maintainer=MAINTAINER,
           maintainer_email=MAINTAINER_EMAIL,

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,21 @@ import subprocess
 import setuptools
 from setuptools import setup
 
-import skvideo
+# https://packaging.python.org/guides/single-sourcing-package-version/
+here = os.path.abspath(os.path.dirname(__file__))
+
+def read(*parts):
+    with codecs.open(os.path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
 
 def configuration(parent_package='', top_path=None, package_name=PACKAGE_NAME):
     if os.path.exists('MANIFEST'): os.remove('MANIFEST')
@@ -86,5 +100,5 @@ if __name__ == "__main__":
           include_package_data=True,
           test_suite="nose.collector",
           cmdclass=cmdclass,
-          version=skvideo.__version__,
+          version=find_version("skvideo", "__init__.py"),
           **EXTRA_INFO)

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ from setuptools import setup
 
 # https://packaging.python.org/guides/single-sourcing-package-version/
 import codecs
+import re
 here = os.path.abspath(os.path.dirname(__file__))
 
 def read(*parts):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ import sys
 import subprocess
 
 import setuptools
-from numpy.distutils.core import setup
+from distutils.core import setup
 
 import skvideo
 

--- a/skvideo/utils/__init__.py
+++ b/skvideo/utils/__init__.py
@@ -6,7 +6,6 @@ import platform
 import itertools
 from .xmltodict import parse as xmltodictparser
 import subprocess as sp
-import numpy as np
 from .edge import canny
 from .stpyr import SpatialSteerablePyramid, rolling_window
 from .mscn import compute_image_mscn_transform, gen_gauss_window
@@ -299,6 +298,7 @@ def vshape(videodata):
         Standardized version of videodata, shape (T, M, N, C)
 
     """
+    import numpy as np
     if not isinstance(videodata, np.ndarray):
         videodata = np.array(videodata)
 


### PR DESCRIPTION
This allows installing scikit-video without installing NumPy first (as things stand setup.py uses numpy.core.distutils.setup), which makes it easier to use scikit-video in CI.

This also allows installing scikit-video directly from GitHub, without which we couldn't test the first thing. You can now try it yourself with `pip install git+https://github.com/dHannasch/scikit-video.git@use-distutils-core-setup`. If this is merged into master, it will be possible to install the latest updates to scikit-video directly from the GitHub master branch with `pip install git+https://github.com/scikit-video/scikit-video.git@master`.