### PR TITLE
Fixed incorrect indexing in SE3SS motion estimation

### DIFF
--- a/skvideo/motion/block.py
+++ b/skvideo/motion/block.py
@@ -468,7 +468,7 @@ def _SE3SS(imgP, imgI, mbSize, p):
                         costs[3] = _costMAD(imgP[i:i + mbSize, j:j + mbSize], imgI[refBlkVerPointD:refBlkVerPointD + mbSize, refBlkHorPointD:refBlkHorPointD + mbSize])
                         computations += 1
 
-                dxy = np.argmin(costs)
+                dxy = np.argmin(costs) + 1
                 cost = costs[dxy]
 
                 if dxy == 2:


### PR DESCRIPTION
The SE3SS code was apparently adapted from Matlab which starts indexing with 1 instead of 0. This fix solves the incorrect adaptation of the original algorithm.