### PR TITLE
Replace `np.int` with `np.int64` for compatibility with latest NumPy versions

### DIFF
--- a/doc/examples/IOcorrupt.py
+++ b/doc/examples/IOcorrupt.py
@@ -7,7 +7,7 @@ filename = skvideo.datasets.bigbuckbunny()
 vid_in = skvideo.io.FFmpegReader(filename)
 data = skvideo.io.ffprobe(filename)['video']
 rate = data['@r_frame_rate']
-T = np.int(data['@nb_frames'])
+T = np.int64(data['@nb_frames'])
 
 vid_out = skvideo.io.FFmpegWriter("corrupted_video.mp4", inputdict={
       '-r': rate,

--- a/doc/examples/scene_parse.py
+++ b/doc/examples/scene_parse.py
@@ -42,9 +42,9 @@ filename = skvideo.datasets.bikes()
 videodata = skvideo.io.vread(filename)
 videometadata = skvideo.io.ffprobe(filename)
 frame_rate = videometadata['video']['@avg_frame_rate']
-num_frames = np.int(videometadata['video']['@nb_frames'])
-width = np.int(videometadata['video']['@width'])
-height = np.int(videometadata['video']['@height'])
+num_frames = np.int64(videometadata['video']['@nb_frames'])
+width = np.int64(videometadata['video']['@width'])
+height = np.int64(videometadata['video']['@height'])
 
 # using the "edge" algorithm
 scene_edge_idx = skvideo.measure.scenedet(videodata, method='edges')

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -78,7 +78,7 @@ class VideoReaderAbstract(object):
 
         self.inputfps = -1
         if ("-r" in inputdict):
-            self.inputfps = np.int(inputdict["-r"])
+            self.inputfps = np.int64(inputdict["-r"])
         elif self.INFO_AVERAGE_FRAMERATE in viddict:
             # check for the slash
             frtxt = viddict[self.INFO_AVERAGE_FRAMERATE]
@@ -106,11 +106,11 @@ class VideoReaderAbstract(object):
         # if we don't have width or height at all, raise exception
         if ("-s" in inputdict):
             widthheight = inputdict["-s"].split('x')
-            self.inputwidth = np.int(widthheight[0])
-            self.inputheight = np.int(widthheight[1])
+            self.inputwidth = np.int64(widthheight[0])
+            self.inputheight = np.int64(widthheight[1])
         elif ((self.INFO_WIDTH in viddict) and (self.INFO_HEIGHT in viddict)):
-            self.inputwidth = np.int(viddict[self.INFO_WIDTH])
-            self.inputheight = np.int(viddict[self.INFO_HEIGHT])
+            self.inputwidth = np.int64(viddict[self.INFO_WIDTH])
+            self.inputheight = np.int64(viddict[self.INFO_HEIGHT])
         else:
             raise ValueError(
                 "No way to determine width or height from video. Need `-s` in `inputdict`. Consult documentation on I/O.")
@@ -134,23 +134,23 @@ class VideoReaderAbstract(object):
                 warnings.warn("No input color space detected. Assuming {}.".format(self.DEFAULT_INPUT_PIX_FMT),
                               UserWarning)
 
-        self.inputdepth = np.int(bpplut[self.pix_fmt][0])
-        self.bpp = np.int(bpplut[self.pix_fmt][1])
+        self.inputdepth = np.int64(bpplut[self.pix_fmt][0])
+        self.bpp = np.int64(bpplut[self.pix_fmt][1])
 
         israw = str.encode(self.extension) in [b".raw", b".yuv"]
         iswebcam = not os.path.isfile(filename)
 
         if ("-vframes" in outputdict):
-            self.inputframenum = np.int(outputdict["-vframes"])
+            self.inputframenum = np.int64(outputdict["-vframes"])
         elif ("-r" in outputdict):
-            inputfps = np.int(outputdict["-r"])
+            inputfps = np.int64(outputdict["-r"])
             inputduration = np.float(viddict[self.INFO_DURATION])
-            self.inputframenum = np.int(round(inputfps * inputduration) + 1)
+            self.inputframenum = np.int64(round(inputfps * inputduration) + 1)
         elif (self.INFO_NB_FRAMES in viddict):
-            self.inputframenum = np.int(viddict[self.INFO_NB_FRAMES])
+            self.inputframenum = np.int64(viddict[self.INFO_NB_FRAMES])
         elif israw:
             # we can compute it based on the input size and color space
-            self.inputframenum = np.int(self.size / (self.inputwidth * self.inputheight * (self.bpp / 8.0)))
+            self.inputframenum = np.int64(self.size / (self.inputwidth * self.inputheight * (self.bpp / 8.0)))
         elif iswebcam:
             # webcam can stream frames endlessly, lets use the special default value of 0 to indicate that
             self.inputframenum = 0
@@ -179,14 +179,14 @@ class VideoReaderAbstract(object):
 
         if '-s' in outputdict:
             widthheight = outputdict["-s"].split('x')
-            self.outputwidth = np.int(widthheight[0])
-            self.outputheight = np.int(widthheight[1])
+            self.outputwidth = np.int64(widthheight[0])
+            self.outputheight = np.int64(widthheight[1])
         else:
             self.outputwidth = self.inputwidth
             self.outputheight = self.inputheight
 
-        self.outputdepth = np.int(bpplut[outputdict['-pix_fmt']][0])
-        self.outputbpp = np.int(bpplut[outputdict['-pix_fmt']][1])
+        self.outputdepth = np.int64(bpplut[outputdict['-pix_fmt']][0])
+        self.outputbpp = np.int64(bpplut[outputdict['-pix_fmt']][1])
         bitpercomponent = self.outputbpp // self.outputdepth
         if bitpercomponent == 8:
             self.dtype = np.dtype('u1')  # np.uint8
@@ -444,8 +444,8 @@ class VideoWriterAbstract(object):
 
         if ("-s" in self.inputdict):
             widthheight = self.inputdict["-s"].split('x')
-            self.inputwidth = np.int(widthheight[0])
-            self.inputheight = np.int(widthheight[1])
+            self.inputwidth = np.int64(widthheight[0])
+            self.inputheight = np.int64(widthheight[1])
         else:
             self.inputdict["-s"] = str(N) + "x" + str(M)
             self.inputwidth = N

--- a/skvideo/io/avconv.py
+++ b/skvideo/io/avconv.py
@@ -60,7 +60,7 @@ class LibAVReader(VideoReaderAbstract):
         probecmd = [_AVCONV_PATH + "/avprobe"] + ["-v", "error", "-count_frames", "-select_streams", "v:0",
                                                   "-show_entries", "stream=nb_read_frames", "-of",
                                                   "default=nokey=1:noprint_wrappers=1", self._filename]
-        return np.int(check_output(probecmd).decode().split('\n')[0])
+        return np.int64(check_output(probecmd).decode().split('\n')[0])
 
     def _probe(self):
         return avprobe(self._filename)

--- a/skvideo/io/ffmpeg.py
+++ b/skvideo/io/ffmpeg.py
@@ -68,7 +68,7 @@ class FFmpegReader(VideoReaderAbstract):
         probecmd = [_FFMPEG_PATH + "/ffprobe"] + ["-v", "error", "-count_frames", "-select_streams", "v:0",
                                                   "-show_entries", "stream=nb_read_frames", "-of",
                                                   "default=nokey=1:noprint_wrappers=1", self._filename]
-        return np.int(check_output(probecmd).decode().split('\n')[0])
+        return np.int64(check_output(probecmd).decode().split('\n')[0])
 
     def _probe(self):
         return ffprobe(self._filename)

--- a/skvideo/measure/Li3DDCT.py
+++ b/skvideo/measure/Li3DDCT.py
@@ -37,8 +37,8 @@ def Li3DDCT_features(videoData):
     assert T >= 4, "Only %d input frames. Please supply at least 4" % (T,)
 
     feats = np.zeros((63*5,), dtype=np.float32)
-    newM = np.int32(np.floor(M/4)*4)
-    newN = np.int32(np.floor(N/4)*4)
+    newM = np.int6432(np.floor(M/4)*4)
+    newN = np.int6432(np.floor(N/4)*4)
 
     frameSlices = np.arange(0, T-4, 4)
     Sfeats = np.zeros((len(frameSlices), 63), dtype=np.float32)

--- a/skvideo/measure/niqe.py
+++ b/skvideo/measure/niqe.py
@@ -34,7 +34,7 @@ def get_patches_test_features(img, patch_size, stride=8):
 
 def extract_on_patches(img, patch_size):
     h, w = img.shape
-    patch_size = np.int(patch_size)
+    patch_size = np.int64(patch_size)
     patches = []
     for j in range(0, h-patch_size+1, patch_size):
         for i in range(0, w-patch_size+1, patch_size):

--- a/skvideo/measure/psnr.py
+++ b/skvideo/measure/psnr.py
@@ -35,7 +35,7 @@ def psnr(referenceVideoData, distortedVideoData, bitdepth=8):
     referenceVideoData = vshape(referenceVideoData)
     distortedVideoData = vshape(distortedVideoData)
 
-    bitdepth = np.int(bitdepth)
+    bitdepth = np.int64(bitdepth)
 
     assert(referenceVideoData.shape == distortedVideoData.shape)
 
@@ -43,7 +43,7 @@ def psnr(referenceVideoData, distortedVideoData, bitdepth=8):
 
     assert C == 1, "psnr called with videos containing %d channels. Please supply only the luminance channel" % (C,)
 
-    maxvalue = np.int(2**bitdepth - 1)
+    maxvalue = np.int64(2**bitdepth - 1)
     maxsq = maxvalue**2
 
     scores = np.zeros(T, dtype=np.float)

--- a/skvideo/measure/ssim.py
+++ b/skvideo/measure/ssim.py
@@ -13,18 +13,18 @@ def _ssim_core(referenceVideoFrame, distortedVideoFrame, K_1, K_2, bitdepth, sca
     if avg_window is None:
       avg_window = gen_gauss_window(5, 1.5)
     
-    L = np.int(2**bitdepth - 1)
+    L = np.int64(2**bitdepth - 1)
 
     C1 = (K_1 * L)**2
     C2 = (K_2 * L)**2
 
-    factor = np.int(np.max((1, np.round(np.min((M, N))/256.0))))
+    factor = np.int64(np.max((1, np.round(np.min((M, N))/256.0))))
     factor_lpf = np.ones((factor,factor), dtype=np.float32)
     factor_lpf /= np.sum(factor_lpf)
 
     if scaleFix:
-      M = np.int(np.round(np.float(M) / factor + 1e-9))
-      N = np.int(np.round(np.float(N) / factor + 1e-9))
+      M = np.int64(np.round(np.float(M) / factor + 1e-9))
+      N = np.int64(np.round(np.float(N) / factor + 1e-9))
 
     mu1 = np.zeros((M, N), dtype=np.float32)
     mu2 = np.zeros((M, N), dtype=np.float32)
@@ -204,11 +204,11 @@ def ssim_full(referenceVideoData, distortedVideoData, K_1 = 0.01, K_2 = 0.03, bi
 
     assert C == 1, "ssim called with videos containing %d channels. Please supply only the luminance channel" % (C,)
 
-    factor = np.int(np.max((1, np.round(np.min((M, N))/256.0))))
+    factor = np.int64(np.max((1, np.round(np.min((M, N))/256.0))))
 
     if scaleFix:
-      M = np.int(np.round(np.float(M) / factor + 1e-9))
-      N = np.int(np.round(np.float(N) / factor + 1e-9))
+      M = np.int64(np.round(np.float(M) / factor + 1e-9))
+      N = np.int64(np.round(np.float(N) / factor + 1e-9))
 
     ssim_maps = np.zeros((T, M-10, N-10), dtype=np.float32)
     contrast_maps = np.zeros((T, M-10, N-10), dtype=np.float32)

--- a/skvideo/measure/strred.py
+++ b/skvideo/measure/strred.py
@@ -6,7 +6,7 @@ import scipy.linalg
 def est_params(frame, blk, sigma_nn):
     h, w = frame.shape
     sizeim = np.floor(np.array(frame.shape)/blk) * blk
-    sizeim = sizeim.astype(np.int)
+    sizeim = sizeim.astype(np.int64)
 
     frame = frame[:sizeim[0], :sizeim[1]]
 
@@ -37,7 +37,7 @@ def est_params(frame, blk, sigma_nn):
     V = V.astype(np.float32)
 
     # Estimate local variance
-    sizeim_reduced = (sizeim/blk).astype(np.int)
+    sizeim_reduced = (sizeim/blk).astype(np.int64)
     ss = np.zeros((sizeim_reduced[0], sizeim_reduced[1]), dtype=np.float32)
     if np.max(V) > 0:
       # avoid the matrix inverse for extra speed/accuracy

--- a/skvideo/measure/videobliinds.py
+++ b/skvideo/measure/videobliinds.py
@@ -19,7 +19,7 @@ def motion_feature_extraction(frames):
     mblock=10
     h = gen_gauss_window(2, 0.5)
     # step 1: motion vector calculation
-    motion_vectors = blockMotion(frames, method='N3SS', mbSize=mblock, p=np.int(1.5*mblock))
+    motion_vectors = blockMotion(frames, method='N3SS', mbSize=mblock, p=np.int64(1.5*mblock))
     motion_vectors = motion_vectors.astype(np.float32)
 
     # step 2: compute coherency
@@ -90,11 +90,11 @@ def _extract_subband_feats(mscncoefs):
 
 def extract_on_patches(img, blocksizerow, blocksizecol):
     h, w = img.shape
-    blocksizerow = np.int(blocksizerow)
-    blocksizecol = np.int(blocksizecol)
+    blocksizerow = np.int64(blocksizerow)
+    blocksizecol = np.int64(blocksizecol)
     patches = []
-    for j in range(0, np.int(h-blocksizerow+1), np.int(blocksizerow)):
-        for i in range(0, np.int(w-blocksizecol+1), np.int(blocksizecol)):
+    for j in range(0, np.int64(h-blocksizerow+1), np.int64(blocksizerow)):
+        for i in range(0, np.int64(w-blocksizecol+1), np.int64(blocksizecol)):
             patch = img[j:j+blocksizerow, i:i+blocksizecol]
             patches.append(patch)
 
@@ -176,8 +176,8 @@ def temporal_dc_variation_feature_extraction(frames):
     frames = frames.astype(np.float32)
     mblock=16
     mbsize=16
-    ih = np.int(frames.shape[1]/mbsize)*mbsize
-    iw = np.int(frames.shape[2]/mbsize)*mbsize
+    ih = np.int64(frames.shape[1]/mbsize)*mbsize
+    iw = np.int64(frames.shape[2]/mbsize)*mbsize
     # step 1: motion vector calculation
     motion_vectors = blockMotion(frames, method='N3SS', mbSize=mblock, p=7)
     # step 2: compensated temporal dct differences
@@ -209,7 +209,7 @@ def NSS_spectral_ratios_feature_extraction(frames):
     mblock=5
 
     # step 1: compute local dct frame differences
-    dct_diff5x5 = np.zeros((frames.shape[0]-1, np.int(frames.shape[1]/mblock), np.int(frames.shape[2]/mblock),mblock**2), dtype=np.float32)
+    dct_diff5x5 = np.zeros((frames.shape[0]-1, np.int64(frames.shape[1]/mblock), np.int64(frames.shape[2]/mblock),mblock**2), dtype=np.float32)
     for i in range(dct_diff5x5.shape[0]):
       for y in range(dct_diff5x5.shape[1]):
         for x in range(dct_diff5x5.shape[2]):
@@ -246,9 +246,9 @@ def NSS_spectral_ratios_feature_extraction(frames):
     for i in range(dct_diff5x5.shape[0]):
       freq_bands[i] = zigzag(gamma_matrix[i])
 
-    lf_gamma5x5 = freq_bands[:, 1:np.int((mblock**2-1)/3)+1]
-    mf_gamma5x5 = freq_bands[:, np.int((mblock**2-1)/3)+1:2*np.int((mblock**2-1)/3)+1]
-    hf_gamma5x5 = freq_bands[:, np.int(2*(mblock**2-1)/3)+1:]
+    lf_gamma5x5 = freq_bands[:, 1:np.int64((mblock**2-1)/3)+1]
+    mf_gamma5x5 = freq_bands[:, np.int64((mblock**2-1)/3)+1:2*np.int64((mblock**2-1)/3)+1]
+    hf_gamma5x5 = freq_bands[:, np.int64(2*(mblock**2-1)/3)+1:]
 
     geomean_lf_gam = scipy.stats.mstats.gmean(lf_gamma5x5.T)
     geomean_mf_gam = scipy.stats.mstats.gmean(mf_gamma5x5.T)

--- a/skvideo/measure/viideo.py
+++ b/skvideo/measure/viideo.py
@@ -63,10 +63,10 @@ def viideo_score(videoData, blocksize=(18, 18), blockoverlap=(8, 8), filterlengt
       step_size = 1
 
     scores = []
-    for itr in range(0, np.int(n_len+1), np.int(step_size)):
+    for itr in range(0, np.int64(n_len+1), np.int64(step_size)):
       f1_cum = []
       f2_cum = []
-      for itr_param in range(itr, np.int(np.min((itr+gap+1, n_len)))):
+      for itr_param in range(itr, np.int64(np.min((itr+gap+1, n_len)))):
         low_Fr1 = features[itr_param, :, 2:14]
         low_Fr2 = features[itr_param+1, :, 2:14]
 
@@ -137,13 +137,13 @@ def viideo_features(videoData, blocksize=(18, 18), blockoverlap=(8, 8), filterle
     blockstrideY = blocksize[0]# - blockoverlap[0]
     blockstrideX = blocksize[1]# - blockoverlap[1]
 
-    Mn = np.int(np.round((M+blockoverlap[0])/np.float32(blocksize[0])))
-    Nn = np.int(np.round((N+blockoverlap[1])/np.float32(blocksize[1])))
+    Mn = np.int64(np.round((M+blockoverlap[0])/np.float32(blocksize[0])))
+    Nn = np.int64(np.round((N+blockoverlap[1])/np.float32(blocksize[1])))
 
     # compute every 2 frames
-    features = np.zeros((np.int(T/2), Mn, Nn, 28), dtype=np.float32)
+    features = np.zeros((np.int64(T/2), Mn, Nn, 28), dtype=np.float32)
 
-    for k in range(np.int(T/2)):
+    for k in range(np.int64(T/2)):
       frame1 = videoData[k*2, :, :, 0].astype(np.float32)
       frame2 = videoData[k*2+1, :, :, 0].astype(np.float32)
 

--- a/skvideo/motion/block.py
+++ b/skvideo/motion/block.py
@@ -12,9 +12,9 @@ def _costMAD(block1, block2):
 
 def _minCost(costs):
     h, w = costs.shape
-    mi = costs[np.int((h-1)/2), np.int((w-1)/2)]
-    dy = np.int((h-1)/2)
-    dx = np.int((w-1)/2)
+    mi = costs[np.int64((h-1)/2), np.int64((w-1)/2)]
+    dy = np.int64((h-1)/2)
+    dx = np.int64((w-1)/2)
     #mi = 65535
     #dy = 0
     #dx = 0
@@ -53,7 +53,7 @@ def _DS(imgP, imgI, mbSize, p):
 
     h, w = imgP.shape
 
-    vectors = np.zeros((np.int(h / mbSize), np.int(w / mbSize), 2))
+    vectors = np.zeros((np.int64(h / mbSize), np.int64(w / mbSize), 2))
     costs = np.ones((9))*65537
 
     L = np.floor(np.log2(p + 1))
@@ -206,7 +206,7 @@ def _DS(imgP, imgI, mbSize, p):
             x += SDSP[point][0]
             y += SDSP[point][1]
 
-            vectors[np.int(i / mbSize), np.int(j / mbSize), :] = [x - j, y - i]
+            vectors[np.int64(i / mbSize), np.int64(j / mbSize), :] = [x - j, y - i]
 
             costs[:] = 65537
 
@@ -228,7 +228,7 @@ def _ARPS(imgP, imgI, mbSize, p):
 
     h, w = imgP.shape
 
-    vectors = np.zeros((np.int(h / mbSize), np.int(w / mbSize), 2))
+    vectors = np.zeros((np.int64(h / mbSize), np.int64(w / mbSize), 2))
     costs = np.ones((6))*65537
 
     SDSP = []
@@ -258,16 +258,16 @@ def _ARPS(imgP, imgI, mbSize, p):
                 stepSize = 2
                 maxIndex = 5
             else:
-                u = vectors[np.int(i / mbSize), np.int(j / mbSize) - 1, 0]
-                v = vectors[np.int(i / mbSize), np.int(j / mbSize) - 1, 1]
-                stepSize = np.int(np.max((np.abs(u), np.abs(v))))
+                u = vectors[np.int64(i / mbSize), np.int64(j / mbSize) - 1, 0]
+                v = vectors[np.int64(i / mbSize), np.int64(j / mbSize) - 1, 1]
+                stepSize = np.int64(np.max((np.abs(u), np.abs(v))))
 
                 if (((np.abs(u) == stepSize) and (np.abs(v) == 0)) or
                     ((np.abs(v) == stepSize) and (np.abs(u) == 0))):
                     maxIndex = 5
                 else:
                     maxIndex = 6
-                    LDSP[5] = [np.int(v), np.int(u)]
+                    LDSP[5] = [np.int64(v), np.int64(u)]
 
             # large diamond search
             LDSP[0] = [0, -stepSize]
@@ -340,7 +340,7 @@ def _ARPS(imgP, imgI, mbSize, p):
                     costs[:] = 65537
                     costs[2] = cost
 
-            vectors[np.int(i / mbSize), np.int(j / mbSize), :] = [x - j, y - i]
+            vectors[np.int64(i / mbSize), np.int64(j / mbSize), :] = [x - j, y - i]
 
             costs[:] = 65537
 
@@ -364,7 +364,7 @@ def _SE3SS(imgP, imgI, mbSize, p):
 
     h, w = imgP.shape
 
-    vectors = np.zeros((np.int(h / mbSize), np.int(w / mbSize), 2))
+    vectors = np.zeros((np.int64(h / mbSize), np.int64(w / mbSize), 2))
     L = np.floor(np.log2(p + 1))
     stepMax = 2**(L - 1)
 
@@ -375,7 +375,7 @@ def _SE3SS(imgP, imgI, mbSize, p):
     for i in range(0, h - mbSize + 1, mbSize):
         for j in range(0, w - mbSize + 1, mbSize):
 
-            stepSize = np.int(stepMax)
+            stepSize = np.int64(stepMax)
             x = j
             y = i
 
@@ -488,9 +488,9 @@ def _SE3SS(imgP, imgI, mbSize, p):
                     y = refBlkVerPointF
 
                 costs[:] = 65537
-                stepSize = np.int(stepSize / 2)
+                stepSize = np.int64(stepSize / 2)
 
-            vectors[np.int(i / mbSize), np.int(j / mbSize), :] = [y - i, x - j]
+            vectors[np.int64(i / mbSize), np.int64(j / mbSize), :] = [y - i, x - j]
 
             costs[:] = 65537
 
@@ -512,19 +512,19 @@ def _N3SS(imgP, imgI, mbSize, p):
 
     h, w = imgP.shape
 
-    h = np.int(h/mbSize) * mbSize
-    w = np.int(w/mbSize) * mbSize
+    h = np.int64(h/mbSize) * mbSize
+    w = np.int64(w/mbSize) * mbSize
     imgP = imgP[:h, :w]
     imgI = imgI[:h, :w]
 
-    vectors = np.zeros((np.int(h / mbSize), np.int(w / mbSize), 2), dtype=np.float32)
+    vectors = np.zeros((np.int64(h / mbSize), np.int64(w / mbSize), 2), dtype=np.float32)
 
     costs = np.ones((3, 3), dtype=np.float32)*65537
 
     computations = 0
 
     L = np.floor(np.log2(p + 1))
-    stepMax = np.int(2**(L - 1))
+    stepMax = np.int64(2**(L - 1))
 
     l_count = 0
     for i in range(0, h - mbSize + 1, mbSize):
@@ -546,8 +546,8 @@ def _N3SS(imgP, imgI, mbSize, p):
                        (refBlkHor < 0) or
                        (refBlkHor + mbSize > w)):
                             continue
-                    costRow = np.int(m / stepSize) + 1
-                    costCol = np.int(n / stepSize) + 1
+                    costRow = np.int64(m / stepSize) + 1
+                    costCol = np.int64(n / stepSize) + 1
                     if ((costRow == 1) and (costCol == 1)):
                         continue
                     costs[costRow, costCol] = _costMAD(imgP[i:i + mbSize, j:j + mbSize], imgI[refBlkVer:refBlkVer + mbSize, refBlkHor:refBlkHor + mbSize])
@@ -612,8 +612,8 @@ def _N3SS(imgP, imgI, mbSize, p):
                             (refBlkHor >= j - 1) and
                             (refBlkHor <= j + 1)):
                                 continue
-                        costRow = np.int(m/stepSize) + 1
-                        costCol = np.int(n/stepSize) + 1
+                        costRow = np.int64(m/stepSize) + 1
+                        costCol = np.int64(n/stepSize) + 1
                         if ((costRow == 1) and (costCol == 1)):
                             continue
                         costs[costRow, costCol] = _costMAD(imgP[i:i + mbSize, j:j + mbSize], imgI[refBlkVer:refBlkVer + mbSize, refBlkHor:refBlkHor + mbSize])
@@ -627,7 +627,7 @@ def _N3SS(imgP, imgI, mbSize, p):
             elif NTSSFlag == 0:
                 costs[:, :] = 65537
                 costs[1, 1] = min1
-                stepSize = np.int(stepMax / 2)
+                stepSize = np.int64(stepMax / 2)
                 while(stepSize >= 1):
                     for m in range(-stepSize, stepSize+1, stepSize):
                         for n in range(-stepSize, stepSize+1, stepSize):
@@ -638,8 +638,8 @@ def _N3SS(imgP, imgI, mbSize, p):
                                (refBlkHor < 0) or
                                (refBlkHor + mbSize > w)):
                                     continue
-                            costRow = np.int(m / stepSize) + 1
-                            costCol = np.int(n / stepSize) + 1
+                            costRow = np.int64(m / stepSize) + 1
+                            costCol = np.int64(n / stepSize) + 1
                             if ((costRow == 1) and (costCol == 1)):
                                 continue
                             costs[costRow, costCol] = _costMAD(imgP[i:i + mbSize, j:j + mbSize], imgI[refBlkVer:refBlkVer + mbSize, refBlkHor:refBlkHor + mbSize])
@@ -649,11 +649,11 @@ def _N3SS(imgP, imgI, mbSize, p):
                     x += (dx - 1) * stepSize
                     y += (dy - 1) * stepSize
 
-                    stepSize = np.int(stepSize / 2)
+                    stepSize = np.int64(stepSize / 2)
                     costs[1, 1] = costs[dy, dx]
 
 
-            vectors[np.int(i / mbSize), np.int(j / mbSize), :] = [y - i, x - j]
+            vectors[np.int64(i / mbSize), np.int64(j / mbSize), :] = [y - i, x - j]
 
             costs[:, :] = 65537
 
@@ -664,13 +664,13 @@ def _N3SS(imgP, imgI, mbSize, p):
 def _3SS(imgP, imgI, mbSize, p):
     h, w = imgP.shape
 
-    vectors = np.zeros((np.int(h / mbSize), np.int(w / mbSize), 2))
+    vectors = np.zeros((np.int64(h / mbSize), np.int64(w / mbSize), 2))
     costs = np.ones((3, 3), dtype=np.float32)*65537
 
     computations = 0
 
     L = np.floor(np.log2(p + 1))
-    stepMax = np.int(2**(L - 1))
+    stepMax = np.int64(2**(L - 1))
 
     for i in range(0, h - mbSize + 1, mbSize):
         for j in range(0, w - mbSize + 1, mbSize):
@@ -692,8 +692,8 @@ def _3SS(imgP, imgI, mbSize, p):
                            (refBlkHor < 0) or
                            (refBlkHor + mbSize > w)):
                                 continue
-                        costRow = np.int(m/stepSize) + 1
-                        costCol = np.int(n/stepSize) + 1
+                        costRow = np.int64(m/stepSize) + 1
+                        costCol = np.int64(n/stepSize) + 1
                         if ((costRow == 1) and (costCol == 1)):
                             continue
                         costs[costRow, costCol] = _costMAD(imgP[i:i + mbSize, j:j + mbSize], imgI[refBlkVer:refBlkVer + mbSize, refBlkHor:refBlkHor + mbSize])
@@ -702,9 +702,9 @@ def _3SS(imgP, imgI, mbSize, p):
                 x += (dx - 1) * stepSize
                 y += (dy - 1) * stepSize
 
-                stepSize = np.int(stepSize / 2)
+                stepSize = np.int64(stepSize / 2)
                 costs[1, 1] = costs[dy, dx]
-            vectors[np.int(i / mbSize), np.int(j / mbSize), :] = [y - i, x - j]
+            vectors[np.int64(i / mbSize), np.int64(j / mbSize), :] = [y - i, x - j]
 
             costs[:, :] = 65537
 
@@ -724,7 +724,7 @@ def _4SS(imgP, imgI, mbSize, p):
     #   SS4computations: The average number of points searched for a macroblock
     h, w = imgP.shape
 
-    vectors = np.zeros((np.int(h / mbSize), np.int(w / mbSize), 2))
+    vectors = np.zeros((np.int64(h / mbSize), np.int64(w / mbSize), 2))
     costs = np.ones((3, 3), dtype=np.float32)*65537
 
     computations = 0
@@ -744,8 +744,8 @@ def _4SS(imgP, imgI, mbSize, p):
                     if not _checkBounded(refBlkHor, refBlkVer, w, h, mbSize):
                         continue
 
-                    costRow = np.int(m/2 + 1)
-                    costCol = np.int(n/2 + 1)
+                    costRow = np.int64(m/2 + 1)
+                    costCol = np.int64(n/2 + 1)
                     if ((costRow == 1) and (costCol == 1)):
                         continue
                     costs[costRow, costCol] = _costMAD(imgP[i:i + mbSize, j:j + mbSize], imgI[refBlkVer:refBlkVer + mbSize, refBlkHor:refBlkHor + mbSize])
@@ -780,8 +780,8 @@ def _4SS(imgP, imgI, mbSize, p):
                             (refBlkVer >= yLast + 2)):
                             continue
 
-                        costRow = np.int(m/2) + 1
-                        costCol = np.int(n/2) + 1
+                        costRow = np.int64(m/2) + 1
+                        costCol = np.int64(n/2) + 1
 
                         if (costRow == 1 and costCol == 1):
                             continue
@@ -824,7 +824,7 @@ def _4SS(imgP, imgI, mbSize, p):
             x += dx - 1
             y += dy - 1
 
-            vectors[np.int(i / mbSize), np.int(j / mbSize), :] = [y - i, x - j]
+            vectors[np.int64(i / mbSize), np.int64(j / mbSize), :] = [y - i, x - j]
 
             costs[:, :] = 65537
 
@@ -835,7 +835,7 @@ def _4SS(imgP, imgI, mbSize, p):
 def _ES(imgP, imgI, mbSize, p):
     h, w = imgP.shape
 
-    vectors = np.zeros((np.int(h / mbSize), np.int(w / mbSize), 2), dtype=np.float32)
+    vectors = np.zeros((np.int64(h / mbSize), np.int64(w / mbSize), 2), dtype=np.float32)
     costs = np.ones((2 * p + 1, 2 * p + 1), dtype=np.float32)*65537
 
     # we start off from the top left of the image
@@ -878,7 +878,7 @@ def _ES(imgP, imgI, mbSize, p):
             # Now we find the vector where the cost is minimum
             # and store it ... this is what will be passed back.
             dx, dy, mi = _minCost(costs)  # finds which macroblock in imgI gave us min Cost
-            vectors[np.int(i / mbSize), np.int(j / mbSize), :] = [dy - p, dx - p]
+            vectors[np.int64(i / mbSize), np.int64(j / mbSize), :] = [dy - p, dx - p]
 
             costs[:, :] = 65537
 
@@ -947,7 +947,7 @@ def blockMotion(videodata, method='DS', mbSize=8, p=2, **plugin_args):
     # luminance is 1 channel, so flatten for computation
     luminancedata = luminancedata.reshape((numFrames, height, width))
 
-    motionData = np.zeros((numFrames - 1, np.int(height / mbSize), np.int(width / mbSize), 2), np.int8)
+    motionData = np.zeros((numFrames - 1, np.int64(height / mbSize), np.int64(width / mbSize), 2), np.int648)
 
     if method == "ES":
         for i in range(numFrames - 1):
@@ -990,8 +990,8 @@ def _subcomp(framedata, motionVect, mbSize):
 
     for i in range(0, M - mbSize + 1, mbSize):
         for j in range(0, N - mbSize + 1, mbSize):
-            dy = motionVect[np.int(i / mbSize), np.int(j / mbSize), 0]
-            dx = motionVect[np.int(i / mbSize), np.int(j / mbSize), 1]
+            dy = motionVect[np.int64(i / mbSize), np.int64(j / mbSize), 0]
+            dx = motionVect[np.int64(i / mbSize), np.int64(j / mbSize), 1]
 
             refBlkVer = i + dy
             refBlkHor = j + dx

--- a/skvideo/tests/test_libav.py
+++ b/skvideo/tests/test_libav.py
@@ -19,7 +19,7 @@ def test_LibAVReader_aboveversion9():
     # skip if libav not installed or of the proper version
     if not skvideo._HAS_AVCONV:
         return 0
-    if np.int(skvideo._LIBAV_MAJOR_VERSION) < 9:
+    if np.int64(skvideo._LIBAV_MAJOR_VERSION) < 9:
         return 0
 
     reader = skvideo.io.LibAVReader(
@@ -114,7 +114,7 @@ def test_LibAVWriter_aboveversion9():
     # skip if libav not installed or of the proper version
     if not skvideo._HAS_AVCONV:
         return 0
-    if np.int(skvideo._LIBAV_MAJOR_VERSION) < 9:
+    if np.int64(skvideo._LIBAV_MAJOR_VERSION) < 9:
         return 0
 
     # generate random data for 5 frames
@@ -154,7 +154,7 @@ def _Gray2RGBHack_Helper(pix_fmt):
     # skip if libav not installed or of the proper version
     if not skvideo._HAS_AVCONV:
         return 0
-    if np.int(skvideo._LIBAV_MAJOR_VERSION) < 9:
+    if np.int64(skvideo._LIBAV_MAJOR_VERSION) < 9:
         return 0
 
     # generate random data for 5 frames

--- a/skvideo/tests/test_vread.py
+++ b/skvideo/tests/test_vread.py
@@ -132,7 +132,7 @@ def test_vread_raw1_ffmpeg():
 def test_vread_raw1_libav_aboveversion9():
     if not skvideo._HAS_AVCONV:
         return 0
-    if np.int(skvideo._LIBAV_MAJOR_VERSION) < 9:
+    if np.int64(skvideo._LIBAV_MAJOR_VERSION) < 9:
         return 0
     _rawhelper1("libav")
 
@@ -145,7 +145,7 @@ def test_vread_raw2_libav_aboveversion9():
     # skip if libav not installed or of the proper version
     if not skvideo._HAS_AVCONV:
         return 0
-    if np.int(skvideo._LIBAV_MAJOR_VERSION) < 9:
+    if np.int64(skvideo._LIBAV_MAJOR_VERSION) < 9:
         return 0
 
     _rawhelper2("libav")

--- a/skvideo/tests/test_vreader.py
+++ b/skvideo/tests/test_vreader.py
@@ -43,7 +43,7 @@ def test_vreader_ffmpeg():
 @unittest.skipIf(not skvideo._HAS_AVCONV, "LibAV required for this test.")
 def test_vreader_libav_version12():
     try:
-        if np.int(skvideo._LIBAV_MAJOR_VERSION) < 12:
+        if np.int64(skvideo._LIBAV_MAJOR_VERSION) < 12:
             return 0
     except:
         return 0

--- a/skvideo/tests/test_vwrite.py
+++ b/skvideo/tests/test_vwrite.py
@@ -42,7 +42,7 @@ def test_vreader_libav():
     if not skvideo._HAS_AVCONV:
         return 0
     try:
-        if np.int(skvideo._LIBAV_MAJOR_VERSION) < 12:
+        if np.int64(skvideo._LIBAV_MAJOR_VERSION) < 12:
             return 0
     except:
         return 0

--- a/skvideo/utils/edge.py
+++ b/skvideo/utils/edge.py
@@ -152,7 +152,7 @@ def canny(frame):
         return low_mask
 
     sums = (np.array(scipy.ndimage.sum(high_mask, labels,
-                             np.arange(count, dtype=np.int32) + 1),
+                             np.arange(count, dtype=np.int6432) + 1),
                      copy=False, ndmin=1))
     good_label = np.zeros((count + 1,), bool)
     good_label[1:] = sums > 0

--- a/skvideo/utils/stpyr.py
+++ b/skvideo/utils/stpyr.py
@@ -222,7 +222,7 @@ class Steerable:
         return X, Y
 
     def pointOp(self, im, Y, X):
-        out = np.interp(im.flatten(), X, Y)
+        out = np.int64erp(im.flatten(), X, Y)
         return np.reshape(out, im.shape)
 
     #divisive normalization (same as DIIVINE)
@@ -424,8 +424,8 @@ class SpatialSteerablePyramid():
   def corr(self, A, fw):
     h, w = A.shape
 
-    sy2 = np.int(np.floor((fw.shape[0] - 1) / 2))
-    sx2 = np.int(np.floor((fw.shape[1] - 1) / 2))
+    sy2 = np.int64(np.floor((fw.shape[0] - 1) / 2))
+    sx2 = np.int64(np.floor((fw.shape[1] - 1) / 2))
 
     # pad the same as the matlabpyrtools
     newpad = np.vstack((A[1:fw.shape[0]-sy2, :][::-1], A, A[h-(fw.shape[0]-sy2):h-1, :][::-1]))#,


### PR DESCRIPTION
Due to [NumPy's recent depreciation](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) of the `np.int` type, scikit-video is now no longer compatible with the latest version of NumPy. 

This MR is replacing all casts using the now depreciated `np.int` to the most common default type for such casts, which is `np.int64`.