### PR TITLE
Scipy.misc deprecated

### DIFF
--- a/skvideo/measure/brisque.py
+++ b/skvideo/measure/brisque.py
@@ -1,4 +1,5 @@
 import numpy as np
+import cv2
 import scipy.fftpack
 import scipy.io
 import scipy.misc
@@ -61,7 +62,7 @@ def brisque_features(videoData):
     feats = np.zeros((T, 36), dtype=np.float32)
     for i in range(T):
       full_scale = videoData[i, :, :, 0].astype(np.float32)
-      half_scale = imresize(full_scale, 0.5, interp="bicubic", mode="F")
+      half_scale = cv2.resize(full_scale, (0, 0), fx=0.5, fy=0.5, interpolation=cv2.INTER_CUBIC)
 
       full_scale, _, _ = compute_image_mscn_transform(full_scale)
       half_scale, _, _ = compute_image_mscn_transform(half_scale)

--- a/skvideo/measure/niqe.py
+++ b/skvideo/measure/niqe.py
@@ -2,6 +2,7 @@ from ..utils import *
 from ..utils.image import imresize
 
 import numpy as np
+import cv2
 import scipy.misc
 import scipy.io
 
@@ -67,7 +68,7 @@ def _get_patches_generic(img, patch_size, is_train, stride):
 
 
     img = img.astype(np.float32)
-    img2 = imresize(img, 0.5, interp="bicubic", mode="F")
+    img2 = cv2.resize(img, (0, 0), fx=0.5, fy=0.5, interpolation=cv2.INTER_CUBIC)
 
     mscn1, var, mu = compute_image_mscn_transform(img)
     mscn1 = mscn1.astype(np.float32)

--- a/skvideo/measure/videobliinds.py
+++ b/skvideo/measure/videobliinds.py
@@ -2,6 +2,7 @@ from os.path import dirname
 from os.path import join
 
 import numpy as np
+import cv2
 import scipy.fftpack
 import scipy.io
 import scipy.misc
@@ -126,7 +127,7 @@ def computequality(img, blocksizerow, blocksizecol, mu_prisparam, cov_prisparam)
         img = img[:, :-woffset]
 
     img = img.astype(np.float32)
-    img2 = imresize(img, 0.5, interp='bicubic', mode='F')
+    img2 = cv2.resize(img, (0, 0), fx=0.5, fy=0.5, interpolation=cv2.INTER_CUBIC)
 
     mscn1, var, mu = compute_image_mscn_transform(img, extend_mode='nearest')
     mscn1 = mscn1.astype(np.float32)


### PR DESCRIPTION
The "scipy.misc.imresize" function, which was used to scale down image arrays by half using bicubic interpolation across three files ("brisque.py", "niqe.py", and "videobliinds.py"), is deprecated in the latest version of the SciPy library. The changes made in these files use the OpenCV library to achieve the same results.

