### PR TITLE
v1.1.14: non-local I/O + Python-3 correctness pass

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,15 @@
 - Documentation: I/O guide gains a "Remote and in-memory I/O" section
   covering URL inputs/outputs, BytesIO round-trip, the streaming-mp4
   default for memory destinations, and a note on ffprobe latency.
+- Documentation fix: the "Tuning FFmpeg Parameters" writer recipe added in
+  v1.1.13 incorrectly placed the output framerate in ``outputdict["-r"]``.
+  Because ``FFmpegWriter`` feeds headerless ``rawvideo`` (assumed 25 fps),
+  ``-r`` must go in ``inputdict`` to set the written video's framerate;
+  ``outputdict["-r"]`` only resamples against the assumed input rate and
+  yields the wrong duration. Recipes corrected and a note added explaining
+  the input-vs-output ``-r`` asymmetry (and why it differs from
+  ``FFmpegReader``). Reopens the documentation concern from #160/#96; see
+  #186 (reported by page200).
 
 1.1.13 (2026-06-01)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,12 @@
   the input-vs-output ``-r`` asymmetry (and why it differs from
   ``FFmpegReader``). Reopens the documentation concern from #160/#96; see
   #186 (reported by page200).
+- Documentation: added an alpha-channel (transparency) writing recipe to
+  the I/O guide. Preserving alpha requires both an alpha-capable
+  codec/container (FFV1/.mkv, QTRLE or PNG/.mov, VP9/.webm, but not
+  H.264/.mp4) and reading back with ``outputdict={"-pix_fmt": "rgba"}``,
+  since the reader defaults to ``rgb24`` and otherwise drops the alpha
+  plane. Addresses the usage confusion in #143.
 
 1.1.13 (2026-06-01)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,9 @@
   …), or a file-like object such as ``io.BytesIO``. The wrapper no longer
   blocks ffmpeg with filesystem-only checks (``os.path.getsize``,
   ``os.path.isfile``, ``os.access(W_OK)``) when the source isn't a local
-  file. Closes #117, #113, #81 (read+write sides for all three).
+  file. Closes #117, #113, #81 on the reader and writer paths. (Note:
+  ``skvideo.io.ffprobe`` itself accepts URLs but not file-like objects;
+  wrap to a ``NamedTemporaryFile`` if you need to probe in-memory bytes.)
 - ``ffprobe`` is invoked against the URL directly for URL inputs, so probing
   is transparent. Note this incurs network latency on ``FFmpegReader``
   construction proportional to the URL's round-trip time.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,40 @@
+1.1.14 (unreleased)
+-------------------
+- **Input source decoupling**: ``vread`` / ``vreader`` / ``vwrite`` and the
+  ``FFmpegReader`` / ``FFmpegWriter`` constructors now accept three kinds
+  of source/destination uniformly — a file path (existing behavior), a URL
+  string (``http://``, ``https://``, ``rtsp://``, ``rtmp://``, ``udp://``,
+  …), or a file-like object such as ``io.BytesIO``. The wrapper no longer
+  blocks ffmpeg with filesystem-only checks (``os.path.getsize``,
+  ``os.path.isfile``, ``os.access(W_OK)``) when the source isn't a local
+  file. Closes #117, #113, #81 (read+write sides for all three).
+- ``ffprobe`` is invoked against the URL directly for URL inputs, so probing
+  is transparent. Note this incurs network latency on ``FFmpegReader``
+  construction proportional to the URL's round-trip time.
+- BytesIO / file-like inputs are spooled to a ``NamedTemporaryFile`` at
+  construction so the rest of the read path (probe, extension heuristics,
+  frame reader, ``start_frame`` seek) operates on a regular path. The
+  spool is required for formats like mp4 whose moov atom needs random
+  access. The temp file is unlinked in ``close()``.
+- BytesIO / file-like outputs are written via ffmpeg's stdout (``pipe:1``)
+  and drained by a background thread into the user's buffer. When the
+  caller doesn't override ``-f``, the wrapper defaults to ``-f mp4`` with
+  ``-movflags frag_keyframe+empty_moov`` so the output is streamable
+  (the default mp4 muxer would otherwise seek back to write the moov atom,
+  which a pipe can't support). Picking ``-f`` explicitly (webm, matroska,
+  mpegts, …) is respected.
+- **Protocol detection**: at first URL use, ``skvideo`` runs
+  ``ffmpeg -protocols`` (cached for the rest of the session) and emits a
+  ``UserWarning`` if the URL's scheme isn't compiled into the local
+  ffmpeg build — typical case is an ffmpeg without OpenSSL hitting an
+  ``https://`` URL. Warning rather than error; ffmpeg's actual stderr
+  (now readable since v1.1.13) still surfaces the underlying problem.
+  ``setFFmpegPath`` clears the protocol cache so a different binary
+  triggers fresh detection.
+- Documentation: I/O guide gains a "Remote and in-memory I/O" section
+  covering URL inputs/outputs, BytesIO round-trip, the streaming-mp4
+  default for memory destinations, and a note on ffprobe latency.
+
 1.1.13 (2026-06-01)
 -------------------
 - ``pathlib.Path`` objects are now accepted everywhere a filename is expected:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,10 +47,25 @@
   #186 (reported by page200).
 - Documentation: added an alpha-channel (transparency) writing recipe to
   the I/O guide. Preserving alpha requires both an alpha-capable
-  codec/container (FFV1/.mkv, QTRLE or PNG/.mov, VP9/.webm, but not
-  H.264/.mp4) and reading back with ``outputdict={"-pix_fmt": "rgba"}``,
-  since the reader defaults to ``rgb24`` and otherwise drops the alpha
-  plane. Addresses the usage confusion in #143.
+  codec/container (FFV1/.mkv, or QTRLE or PNG/.mov; not H.264/.mp4) and
+  reading back with ``outputdict={"-pix_fmt": "rgba"}``, since the reader
+  defaults to ``rgb24`` and otherwise drops the alpha plane. VP9/.webm
+  alpha is also documented with the caveat that the decoder may need to
+  be named explicitly on read. Addresses the usage confusion in #143.
+- Fixed a file-descriptor leak: ``FFmpegWriter.close()`` returned early
+  without closing its ``DEVNULL`` handle when the writer was constructed
+  but never warm-started (no frames written), e.g. URL/validation-only
+  writers. ``close()`` now releases ``DEVNULL`` on every path.
+- Fixed temp-file leaks on the BytesIO/file-like read path: spooling now
+  unlinks its ``NamedTemporaryFile`` if the source read fails partway,
+  and ``vread`` closes the reader in a ``finally`` so a mid-read error no
+  longer leaks the spooled file. A file-like input without a ``read()``
+  method is now rejected up front with a clear ``TypeError`` instead of
+  failing deep inside the copy.
+- Documentation fix: the frame-exact ``select`` recipe (and the
+  ``start_frame`` docstring) placed ``-vf`` in ``inputdict``; ``-vf`` is
+  an output filter and yields no frames there. Corrected to ``outputdict``.
+  Also added a missing ``import numpy as np`` to the reader example.
 
 1.1.13 (2026-06-01)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -112,6 +112,24 @@
     fallback that raw video relies on), instead of swallowing failures
     silently.
 
+- **Edge-case hardening** (adversarial input testing; failures that were
+  silent or crashed on otherwise-normal input):
+
+  - Full-reference metrics (``mse``/``mae``/``psnr``/``ssim``/``msssim``/
+    ``strred``) and ``globalEdgeMotion`` raised a bare ``assert`` on a
+    ref/dis shape mismatch, and ``blockMotion`` on frame count; under
+    ``python -O`` these vanished and mismatched arrays broadcast to a
+    plausible-but-wrong score. Now raise ``ValueError``.
+  - ``blockComp`` silently zeroed the bottom/right border for frames whose
+    dimensions are not a multiple of ``mbSize`` (e.g. any 1080p frame with
+    ``mbSize=16``). The uncovered remainder now passes through unchanged;
+    evenly-divisible frames are unaffected.
+  - ``blockComp`` no longer crashes on the documented single-frame input.
+  - ``globalEdgeMotion`` on edgeless frames returns ``[0, 0]`` instead of a
+    meaningless ``(-r, -r)`` or a crash.
+  - ``vwrite`` on a zero-frame array now raises ``ValueError`` instead of
+    silently writing no file.
+
 1.1.13 (2026-06-01)
 -------------------
 - ``pathlib.Path`` objects are now accepted everywhere a filename is expected:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -138,6 +138,15 @@
     passthrough; ``globalEdgeMotion``'s ``[0, 0]`` edgeless sentinel; and
     that a low-level ``FFmpegWriter`` closed without frames is an
     intentional no-op (use ``vwrite`` for the guarded 0-frame check).
+  - ``blockComp`` validates the full motion-vector shape
+    ``(M//mbSize, N//mbSize, 2)`` (a wrong rank or last dimension was a
+    cryptic ``IndexError`` or silently accepted).
+  - The ``BytesIO`` writer now closes the ffmpeg subprocess pipe objects on
+    ``close()``, eliminating a ``ResourceWarning: unclosed file`` per writer
+    (no fd leak existed; the warnings were noise).
+  - ``setFFmpegPath`` on a non-existent path now also clears the cached
+    decoder/encoder lists, so a bad path no longer leaves the module
+    half-configured with stale codec data.
 
 1.1.13 (2026-06-01)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,8 +64,20 @@
   failing deep inside the copy.
 - Documentation fix: the frame-exact ``select`` recipe (and the
   ``start_frame`` docstring) placed ``-vf`` in ``inputdict``; ``-vf`` is
-  an output filter and yields no frames there. Corrected to ``outputdict``.
-  Also added a missing ``import numpy as np`` to the reader example.
+  an output filter and yields no frames there. Corrected to ``outputdict``
+  and added the required ``-vsync 0`` (without it FFmpeg re-pads the
+  frames ``select`` drops back to a constant rate, silently undoing the
+  selection). Also added a missing ``import numpy as np`` to the reader
+  example.
+- ``vread`` now trims its result to the number of frames actually
+  produced. When an output filter such as ``-vf select`` yields fewer
+  frames than ``getShape()`` predicted from ``nb_frames``, the returned
+  array previously kept the extra, uninitialized ``np.empty`` rows.
+- The readable-input check for file-like sources is stricter: a file
+  opened in write mode (``"wb"``) exposes a ``read`` attribute that
+  raises when called, so it now fails the ``readable()`` probe and is
+  rejected with a clear ``TypeError`` instead of an opaque
+  ``io.UnsupportedOperation`` from inside the spool copy.
 
 1.1.13 (2026-06-01)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-1.1.14 (unreleased)
+1.1.14 (2026-06-02)
 -------------------
 - **Input source decoupling**: ``vread`` / ``vreader`` / ``vwrite`` and the
   ``FFmpegReader`` / ``FFmpegWriter`` constructors now accept three kinds

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,6 +79,39 @@
   rejected with a clear ``TypeError`` instead of an opaque
   ``io.UnsupportedOperation`` from inside the spool copy.
 
+- **Python-3 correctness pass** (pre-existing defects found in a
+  whole-codebase audit; none were introduced by the v1.1.14 work):
+
+  - ``skvideo.measure.Li3DDCT_features`` raised ``NameError: name 'int32'
+    is not defined`` on every call (bare ``int32`` instead of
+    ``np.int32``) and produced no frame groups when ``T == 4``. Fixed
+    both; the function now runs.
+  - ``skvideo.utils.canny`` (used by ``globalEdgeMotion`` and scene
+    detection) had the same bare ``int32`` ``NameError``. Fixed.
+  - ``skvideo.motion.globalEdgeMotion`` was broken on Python 3: the bool
+    edge-mask path was not squeezed to 2D, the hausdorff branch compared
+    the shifted frame against itself instead of the reference frame, and
+    an unknown method raised a misspelled ``Notimplemented``. All fixed;
+    both ``hamming`` and ``hausdorff`` now recover a known translation.
+  - ``skvideo.motion.blockComp`` dropped every bottom/right macroblock
+    because ``_checkBounded`` rejected blocks ending exactly at the frame
+    edge (``>=`` should have been ``>``). Motion compensation now covers
+    the full frame.
+  - ``from skvideo import *`` raised ``TypeError`` because the top-level
+    ``__all__`` listed function objects instead of names. Fixed.
+  - Library code no longer calls ``exit()`` or raises the ``NotImplemented``
+    singleton: ``rgb2gray``, ``niqe`` and ``videobliinds`` helpers now
+    raise proper exceptions.
+  - Public input validation in the quality metrics (channel / frame-count
+    / resolution checks) and in the I/O layer (unknown extension, unwritable
+    output directory, channel/pixel-format mismatch) now raises
+    ``ValueError`` / ``OSError`` instead of ``assert``, so it is no longer
+    stripped under ``python -O``.
+  - ``ffprobe`` / ``avprobe`` / ``mprobe`` now emit a ``UserWarning`` with
+    the underlying error before returning ``{}`` (the empty-metadata
+    fallback that raw video relies on), instead of swallowing failures
+    silently.
+
 1.1.13 (2026-06-01)
 -------------------
 - ``pathlib.Path`` objects are now accepted everywhere a filename is expected:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -129,6 +129,15 @@
     meaningless ``(-r, -r)`` or a crash.
   - ``vwrite`` on a zero-frame array now raises ``ValueError`` instead of
     silently writing no file.
+  - ``blockComp`` validates the motion-vector grid against the macroblock
+    grid (a mismatch raised a cryptic ``IndexError`` or silently ignored
+    extra vectors; now ``ValueError``), and its single-frame result is now
+    ``(1, M, N, C)`` to match the documented shape.
+  - Documented previously-implicit behaviors: ``blockComp`` output dtype
+    (``float64``), non-divisible-border passthrough, out-of-bounds-vector
+    passthrough; ``globalEdgeMotion``'s ``[0, 0]`` edgeless sentinel; and
+    that a low-level ``FFmpegWriter`` closed without frames is an
+    intentional no-op (use ``vwrite`` for the guarded 0-frame check).
 
 1.1.13 (2026-06-01)
 -------------------

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -274,7 +274,11 @@ Two details matter here. ``select`` is an *output* filter, so it goes in
 frames. And ``-vsync 0`` is required: ``select`` drops frames, and without
 it FFmpeg re-pads the gaps back to a constant frame rate by duplicating
 frames, which silently undoes the selection. With ``-vsync 0`` each
-surviving frame is emitted exactly once.
+surviving frame is emitted exactly once. (On FFmpeg 5.1 and newer,
+``-vsync 0`` is a deprecated alias for ``-fps_mode passthrough`` and may
+print a deprecation notice; ``-vsync 0`` is used here because it works
+across the FFmpeg versions scikit-video supports. On a recent-only
+FFmpeg you can use ``"-fps_mode": "passthrough"`` instead.)
 
 **Muxing audio from a separate source** (added in v1.1.12) uses the
 ``audiosrc`` constructor argument rather than ``inputdict``:

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -234,18 +234,25 @@ See the :class:`skvideo.io.FFmpegWriter` API reference for the full
 Remote and in-memory I/O
 ------------------------
 
-As of v1.1.14, every function and class that accepts a video filename also
-accepts:
+As of v1.1.14, the I/O entry points accept three kinds of source/destination:
 
+* a **file path** — string or ``pathlib.Path`` (existing behavior).
 * a **URL string** — anything matching ``<scheme>://...``, such as
   ``http://``, ``https://``, ``rtsp://``, ``rtmp://``, ``udp://``,
   ``ftp://``, etc. FFmpeg's own protocol handlers take it from there.
 * a **file-like object** — ``io.BytesIO``, an open file handle, anything
-  with a ``.read()`` / ``.write()`` method.
+  with a ``.read()`` (for input) or ``.write()`` (for output) method.
 
-This covers the read side and the write side: pass a URL or a BytesIO to
-``vread`` / ``vreader`` / ``FFmpegReader`` to consume, or to ``vwrite`` /
-``FFmpegWriter`` to produce.
+Specifically:
+
+* :func:`skvideo.io.vread`, :func:`skvideo.io.vreader`, and
+  :class:`skvideo.io.FFmpegReader` accept all three on input.
+* :func:`skvideo.io.vwrite` and :class:`skvideo.io.FFmpegWriter` accept
+  all three on output.
+* :func:`skvideo.io.ffprobe` accepts a file path or a URL string. It does
+  **not** accept a file-like object — wrap the bytes in a
+  ``NamedTemporaryFile`` and call ``ffprobe`` on the resulting path if
+  you need metadata from in-memory bytes.
 
 **Read from a URL:**
 

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -203,6 +203,29 @@ Write a high-quality H.264 with a constant rate factor:
         outputdict={"-vcodec": "libx264", "-crf": "18", "-pix_fmt": "yuv420p"},
     )
 
+Preserve an alpha (transparency) channel. Two things are required:
+the codec/container must support alpha (H.264/``.mp4`` does **not**;
+use FFV1 in ``.mkv``, QTRLE/PNG in ``.mov``, or VP9 in ``.webm``), and
+the output ``-pix_fmt`` must keep the alpha plane (e.g. ``rgba``):
+
+.. code-block:: python
+
+    # frames is an (T, H, W, 4) uint8 array
+    writer = skvideo.io.FFmpegWriter(
+        "out.mkv",
+        inputdict={"-r": "10"},
+        outputdict={"-vcodec": "ffv1", "-pix_fmt": "rgba"},
+    )
+
+When reading the file back, you must also ask for a 4-channel pixel
+format — the reader defaults to ``rgb24`` and would otherwise silently
+drop the alpha plane:
+
+.. code-block:: python
+
+    vid = skvideo.io.vread("out.mkv", outputdict={"-pix_fmt": "rgba"})
+    # vid.shape == (T, H, W, 4)
+
 **Repeating the same flag** (e.g. multiple ``-metadata`` or ``-map``
 entries) is done with a list value — scikit-video emits the flag once per
 list element:

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -265,13 +265,16 @@ instead — slower because FFmpeg decodes from the start of the file:
 
     skvideo.io.vread(
         "clip.mp4",
-        outputdict={"-vf": "select='gte(n\\,1000)'"},
+        outputdict={"-vf": "select='gte(n\\,1000)'", "-vsync": "0"},
         num_frames=200,
     )
 
-The ``select`` filter is an *output* filter, so it goes in ``outputdict``
-(after ``-i``). Placing ``-vf`` in ``inputdict`` applies it before the
-input is opened and yields no frames.
+Two details matter here. ``select`` is an *output* filter, so it goes in
+``outputdict`` (after ``-i``); placing ``-vf`` in ``inputdict`` yields no
+frames. And ``-vsync 0`` is required: ``select`` drops frames, and without
+it FFmpeg re-pads the gaps back to a constant frame rate by duplicating
+frames, which silently undoes the selection. With ``-vsync 0`` each
+surviving frame is emitted exactly once.
 
 **Muxing audio from a separate source** (added in v1.1.12) uses the
 ``audiosrc`` constructor argument rather than ``inputdict``:

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -120,6 +120,21 @@ https://ffmpeg.org/ffmpeg.html.
 command line (they describe how to interpret the input), and ``outputdict``
 parameters are placed *after* (they describe what to do on the way out).
 
+.. note::
+
+   ``FFmpegWriter`` feeds your NumPy frames to FFmpeg as headerless
+   ``rawvideo`` over a pipe, so the stream carries no framerate of its
+   own (FFmpeg assumes 25 fps unless told otherwise). To set the
+   framerate of the written video, put ``-r`` in **inputdict**, not
+   ``outputdict``. ``-r`` before ``-i`` declares the framerate of the
+   incoming frames; ``-r`` after ``-i`` (i.e. in ``outputdict``) is a
+   *resampler* that drops or duplicates frames relative to the input
+   rate. Setting only ``outputdict["-r"]`` resamples against the
+   assumed 25 fps and produces the wrong duration. (This is the reverse
+   of ``FFmpegReader``, whose input is a real container with its own
+   framerate header, so resampling on the output side is the natural
+   knob there.)
+
 **Common reading recipes**
 
 Force a different output pixel format (default is ``rgb24``):
@@ -151,28 +166,32 @@ Read a raw YUV file with no header (size and format must be supplied):
 
 **Common writing recipes**
 
-Pick a specific codec, bitrate, and framerate:
+Pick a specific codec, bitrate, and framerate. Note ``-r`` (the
+framerate of the frames you write) goes in ``inputdict``; see the note
+above:
 
 .. code-block:: python
 
     writer = skvideo.io.FFmpegWriter(
         "out.mp4",
+        inputdict={"-r": "30"},      # framerate of the written video
         outputdict={
             "-vcodec": "libx264",
             "-b:v": "2000k",
-            "-r": "30",
         },
     )
 
-Resample to a different framerate (FFmpeg drops or duplicates frames as
-needed):
+Resample to a different framerate, i.e. write at a different rate than the
+frames are produced (FFmpeg drops or duplicates frames as needed). Here
+``inputdict["-r"]`` sets the source rate and ``outputdict["-r"]`` is the
+resampler:
 
 .. code-block:: python
 
     writer = skvideo.io.FFmpegWriter(
         "out.mp4",
-        inputdict={"-r": "60"},      # source framerate
-        outputdict={"-r": "30"},     # target framerate
+        inputdict={"-r": "60"},      # rate of the frames you write
+        outputdict={"-r": "30"},     # resample to this rate on output
     )
 
 Write a high-quality H.264 with a constant rate factor:

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -54,6 +54,7 @@ Sometimes, particular use cases require fine tuning FFmpeg's reading parameters.
 
 .. code-block:: python
 
+	import numpy as np
 	import skvideo.io
 	import skvideo.datasets
 
@@ -205,8 +206,8 @@ Write a high-quality H.264 with a constant rate factor:
 
 Preserve an alpha (transparency) channel. Two things are required:
 the codec/container must support alpha (H.264/``.mp4`` does **not**;
-use FFV1 in ``.mkv``, QTRLE/PNG in ``.mov``, or VP9 in ``.webm``), and
-the output ``-pix_fmt`` must keep the alpha plane (e.g. ``rgba``):
+use FFV1 in ``.mkv``, or QTRLE or PNG in ``.mov``), and the output
+``-pix_fmt`` must keep the alpha plane (e.g. ``rgba``):
 
 .. code-block:: python
 
@@ -225,6 +226,12 @@ drop the alpha plane:
 
     vid = skvideo.io.vread("out.mkv", outputdict={"-pix_fmt": "rgba"})
     # vid.shape == (T, H, W, 4)
+
+VP9 in ``.webm`` can also carry alpha, but FFmpeg does not always
+auto-select the alpha-aware decoder on read, so a plain ``rgba`` read may
+come back fully opaque. Name the decoder explicitly to recover the alpha
+plane: ``vread("out.webm", inputdict={"-vcodec": "libvpx-vp9"},
+outputdict={"-pix_fmt": "rgba"})``.
 
 **Repeating the same flag** (e.g. multiple ``-metadata`` or ``-map``
 entries) is done with a list value — scikit-video emits the flag once per
@@ -258,9 +265,13 @@ instead — slower because FFmpeg decodes from the start of the file:
 
     skvideo.io.vread(
         "clip.mp4",
-        inputdict={"-vf": "select='gte(n\\,1000)'"},
+        outputdict={"-vf": "select='gte(n\\,1000)'"},
         num_frames=200,
     )
+
+The ``select`` filter is an *output* filter, so it goes in ``outputdict``
+(after ``-i``). Placing ``-vf`` in ``inputdict`` applies it before the
+input is opened and yields no frames.
 
 **Muxing audio from a separate source** (added in v1.1.12) uses the
 ``audiosrc`` constructor argument rather than ``inputdict``:

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -231,6 +231,93 @@ See the :class:`skvideo.io.FFmpegWriter` API reference for the full
 ``audiosrc`` / ``-map`` interaction.
 
 
+Remote and in-memory I/O
+------------------------
+
+As of v1.1.14, every function and class that accepts a video filename also
+accepts:
+
+* a **URL string** — anything matching ``<scheme>://...``, such as
+  ``http://``, ``https://``, ``rtsp://``, ``rtmp://``, ``udp://``,
+  ``ftp://``, etc. FFmpeg's own protocol handlers take it from there.
+* a **file-like object** — ``io.BytesIO``, an open file handle, anything
+  with a ``.read()`` / ``.write()`` method.
+
+This covers the read side and the write side: pass a URL or a BytesIO to
+``vread`` / ``vreader`` / ``FFmpegReader`` to consume, or to ``vwrite`` /
+``FFmpegWriter`` to produce.
+
+**Read from a URL:**
+
+.. code-block:: python
+
+    videodata = skvideo.io.vread("https://example.com/clip.mp4", num_frames=10)
+
+``ffprobe`` is invoked against the URL directly to read metadata, which
+adds network round-trip latency to ``FFmpegReader`` construction. For
+high-volume use, consider downloading first or caching the probe result.
+
+**Read from a BytesIO:**
+
+.. code-block:: python
+
+    import io
+    raw_bytes = open("clip.mp4", "rb").read()
+    buf = io.BytesIO(raw_bytes)
+    videodata = skvideo.io.vread(buf, num_frames=10)
+
+Memory inputs are spooled to a temporary file at construction so the rest
+of the read path can operate on a regular filename (container formats
+like mp4 need random access to read their header atoms, which subprocess
+stdin can't reliably provide). The temp file is unlinked on
+``reader.close()`` / when ``vread`` returns.
+
+**Write to a URL** (e.g. RTMP push to a streaming server):
+
+.. code-block:: python
+
+    writer = skvideo.io.FFmpegWriter(
+        "rtmp://live.example.com/stream/key",
+        outputdict={"-f": "flv", "-vcodec": "libx264", "-preset": "ultrafast"},
+    )
+    for frame in frames:
+        writer.writeFrame(frame)
+    writer.close()
+
+**Write to a BytesIO:**
+
+.. code-block:: python
+
+    import io
+    out = io.BytesIO()
+    skvideo.io.vwrite(out, videodata)
+    out.seek(0)
+    # `out` now contains a streamable fragmented-mp4 file
+
+When writing to a memory destination and the caller doesn't override
+``-f``, the wrapper defaults to ``-f mp4`` with
+``-movflags frag_keyframe+empty_moov`` so the bytes can stream as they're
+produced (the default mp4 muxer would seek back to rewrite the moov atom
+at end-of-encode, which a pipe can't support). To pick a different
+streamable container, set ``-f`` explicitly:
+
+.. code-block:: python
+
+    out = io.BytesIO()
+    writer = skvideo.io.FFmpegWriter(
+        out,
+        outputdict={"-f": "webm", "-vcodec": "libvpx-vp9", "-b:v": "1M"},
+    )
+
+**Protocol detection.** On first URL use, ``skvideo`` runs
+``ffmpeg -protocols`` and caches the result. If the URL's scheme isn't in
+the local ffmpeg's supported list (most commonly: an ffmpeg built without
+OpenSSL hitting an ``https://`` URL), a ``UserWarning`` is emitted so the
+underlying problem is obvious. FFmpeg's actual stderr (now surfaced via
+``RuntimeError`` since v1.1.13) still reports the real failure if you
+proceed.
+
+
 Reading Video Metadata
 -----------------------
 

--- a/skvideo/__init__.py
+++ b/skvideo/__init__.py
@@ -41,11 +41,13 @@ _FFMPEG_SUPPORTED_ENCODERS = []
 _LIBAV_SUPPORTED_EXT = []
 
 # Lazy cache of `ffmpeg -protocols` output (issue #117, v1.1.14 protocol
-# detection). A single tuple ``(input_list, output_list)`` so the publish
-# is atomic — two threads racing past the cache check can never observe
-# one half populated and the other half None (Codex round 1 finding).
-# Reset to None by setFFmpegPath so a different ffmpeg binary triggers
-# fresh detection.
+# detection). Stored as a single tuple ``(input_list, output_list)`` and
+# published in one assignment, so a reader that races past the cache
+# check sees either None or a fully populated tuple, never a half-filled
+# pair. This is not a lock: a concurrent setFFmpegPath() reset can still
+# race a populate, in which case detection simply runs again; the cost
+# is a redundant `ffmpeg -protocols` call, not corruption. Reset to None
+# by setFFmpegPath so a different ffmpeg binary triggers fresh detection.
 _FFMPEG_PROTOCOLS = None
 
 _FFPROBE_APPLICATION = "ffprobe"

--- a/skvideo/__init__.py
+++ b/skvideo/__init__.py
@@ -508,10 +508,10 @@ if (len(_AVCONV_PATH) > 0):
 
 
 __all__ = [
-    getFFmpegPath,
-    getFFmpegVersion,
-    setFFmpegPath,
-    getLibAVPath,
-    getLibAVVersion,
-    setLibAVPath,
+    "getFFmpegPath",
+    "getFFmpegVersion",
+    "setFFmpegPath",
+    "getLibAVPath",
+    "getLibAVVersion",
+    "setLibAVPath",
 ]

--- a/skvideo/__init__.py
+++ b/skvideo/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.13"
+__version__ = "1.1.14.dev0"
 
 from .utils import check_output, where
 import os

--- a/skvideo/__init__.py
+++ b/skvideo/__init__.py
@@ -41,12 +41,12 @@ _FFMPEG_SUPPORTED_ENCODERS = []
 _LIBAV_SUPPORTED_EXT = []
 
 # Lazy cache of `ffmpeg -protocols` output (issue #117, v1.1.14 protocol
-# detection). Lists of bare scheme names ("http", "https", "rtmp", ...) the
-# installed ffmpeg can read from / write to respectively. None until the
-# first call to _get_ffmpeg_protocols(); reset to None by setFFmpegPath
-# (so a different ffmpeg binary triggers a fresh detection).
-_FFMPEG_INPUT_PROTOCOLS = None
-_FFMPEG_OUTPUT_PROTOCOLS = None
+# detection). A single tuple ``(input_list, output_list)`` so the publish
+# is atomic — two threads racing past the cache check can never observe
+# one half populated and the other half None (Codex round 1 finding).
+# Reset to None by setFFmpegPath so a different ffmpeg binary triggers
+# fresh detection.
+_FFMPEG_PROTOCOLS = None
 
 _FFPROBE_APPLICATION = "ffprobe"
 _FFMPEG_APPLICATION = "ffmpeg"
@@ -247,15 +247,17 @@ def _get_ffmpeg_protocols():
     URL). Returns empty lists on detection failure — callers fall back
     to letting ffmpeg surface its own error.
     """
-    global _FFMPEG_INPUT_PROTOCOLS, _FFMPEG_OUTPUT_PROTOCOLS
-    if _FFMPEG_INPUT_PROTOCOLS is not None:
-        return _FFMPEG_INPUT_PROTOCOLS, _FFMPEG_OUTPUT_PROTOCOLS
+    global _FFMPEG_PROTOCOLS
+    # Read once into a local so concurrent setFFmpegPath() can't null
+    # this out from under us mid-function.
+    cached = _FFMPEG_PROTOCOLS
+    if cached is not None:
+        return cached
 
     inputs, outputs = [], []
     if not _HAS_FFMPEG:
-        _FFMPEG_INPUT_PROTOCOLS = inputs
-        _FFMPEG_OUTPUT_PROTOCOLS = outputs
-        return inputs, outputs
+        _FFMPEG_PROTOCOLS = (inputs, outputs)
+        return _FFMPEG_PROTOCOLS
 
     try:
         raw = check_output(
@@ -290,9 +292,10 @@ def _get_ffmpeg_protocols():
         # the protocol really isn't supported.
         pass
 
-    _FFMPEG_INPUT_PROTOCOLS = inputs
-    _FFMPEG_OUTPUT_PROTOCOLS = outputs
-    return inputs, outputs
+    # Single atomic publish so concurrent readers see a fully populated
+    # cache or nothing — no half-state with inputs set but outputs None.
+    _FFMPEG_PROTOCOLS = (inputs, outputs)
+    return _FFMPEG_PROTOCOLS
 
 
 def _warn_if_unsupported_protocol(url, direction):
@@ -406,12 +409,11 @@ def setFFmpegPath(path):
     """
     global _FFMPEG_PATH
     global _HAS_FFMPEG
-    global _FFMPEG_INPUT_PROTOCOLS, _FFMPEG_OUTPUT_PROTOCOLS
+    global _FFMPEG_PROTOCOLS
     _FFMPEG_PATH = path
     # New binary may have different compiled-in protocol support; clear
     # the cache so the next URL use re-detects (issue #117 protocol check).
-    _FFMPEG_INPUT_PROTOCOLS = None
-    _FFMPEG_OUTPUT_PROTOCOLS = None
+    _FFMPEG_PROTOCOLS = None
 
     # check to see if the executables actually exist on these paths
     if os.path.isfile(os.path.join(_FFMPEG_PATH, _FFMPEG_APPLICATION)) and os.path.isfile(os.path.join(_FFMPEG_PATH, _FFPROBE_APPLICATION)):

--- a/skvideo/__init__.py
+++ b/skvideo/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.14.dev0"
+__version__ = "1.1.14"
 
 from .utils import check_output, where
 import os

--- a/skvideo/__init__.py
+++ b/skvideo/__init__.py
@@ -40,6 +40,14 @@ _FFMPEG_SUPPORTED_DECODERS = []
 _FFMPEG_SUPPORTED_ENCODERS = []
 _LIBAV_SUPPORTED_EXT = []
 
+# Lazy cache of `ffmpeg -protocols` output (issue #117, v1.1.14 protocol
+# detection). Lists of bare scheme names ("http", "https", "rtmp", ...) the
+# installed ffmpeg can read from / write to respectively. None until the
+# first call to _get_ffmpeg_protocols(); reset to None by setFFmpegPath
+# (so a different ffmpeg binary triggers a fresh detection).
+_FFMPEG_INPUT_PROTOCOLS = None
+_FFMPEG_OUTPUT_PROTOCOLS = None
+
 _FFPROBE_APPLICATION = "ffprobe"
 _FFMPEG_APPLICATION = "ffmpeg"
 _AVPROBE_APPLICATION = "avprobe"
@@ -225,6 +233,107 @@ def scan_ffmpeg():
     ]
 
 
+def _get_ffmpeg_protocols():
+    """Return (input_protocols, output_protocols) supported by the installed ffmpeg.
+
+    Lazily caches the result so the subprocess call only runs once per
+    interpreter (or until ``setFFmpegPath`` is called, which resets the
+    cache). Each return value is a list of bare scheme names like
+    ``["file", "http", "https", "pipe", "rtsp", ...]``.
+
+    Used by ``_warn_if_unsupported_protocol`` to give users a useful
+    heads-up when their URL scheme isn't compiled into their ffmpeg
+    build (e.g. an ffmpeg without HTTPS support hitting an https://
+    URL). Returns empty lists on detection failure — callers fall back
+    to letting ffmpeg surface its own error.
+    """
+    global _FFMPEG_INPUT_PROTOCOLS, _FFMPEG_OUTPUT_PROTOCOLS
+    if _FFMPEG_INPUT_PROTOCOLS is not None:
+        return _FFMPEG_INPUT_PROTOCOLS, _FFMPEG_OUTPUT_PROTOCOLS
+
+    inputs, outputs = [], []
+    if not _HAS_FFMPEG:
+        _FFMPEG_INPUT_PROTOCOLS = inputs
+        _FFMPEG_OUTPUT_PROTOCOLS = outputs
+        return inputs, outputs
+
+    try:
+        raw = check_output(
+            [os.path.join(_FFMPEG_PATH, _FFMPEG_APPLICATION), "-hide_banner", "-protocols"]
+        ).decode(errors="replace")
+        # ffmpeg -protocols layout:
+        #   Input:
+        #     file
+        #     http
+        #     ...
+        #   Output:
+        #     file
+        #     md5
+        #     ...
+        section = None
+        for line in raw.splitlines():
+            stripped = line.strip()
+            if stripped.lower().startswith("input"):
+                section = "input"
+                continue
+            if stripped.lower().startswith("output"):
+                section = "output"
+                continue
+            if not stripped or ":" in stripped:
+                continue
+            if section == "input":
+                inputs.append(stripped)
+            elif section == "output":
+                outputs.append(stripped)
+    except Exception:
+        # Detection is best-effort; ffmpeg will surface its own error if
+        # the protocol really isn't supported.
+        pass
+
+    _FFMPEG_INPUT_PROTOCOLS = inputs
+    _FFMPEG_OUTPUT_PROTOCOLS = outputs
+    return inputs, outputs
+
+
+def _warn_if_unsupported_protocol(url, direction):
+    """Emit a UserWarning if ``url``'s scheme isn't in ffmpeg's protocol list.
+
+    ``direction`` is either ``"input"`` (reader) or ``"output"`` (writer).
+    Silent no-op for non-URL strings, for ffmpeg builds whose protocol list
+    we couldn't detect (empty list), or for protocols that are present.
+
+    We warn rather than raise so the user gets ffmpeg's own (now-readable)
+    stderr if they choose to proceed — the warning just makes the root
+    cause obvious. Typical case: an ffmpeg compiled without OpenSSL
+    support refusing to handle https:// URLs.
+    """
+    import re as _re
+    import warnings as _warnings
+
+    m = _re.match(r"^([a-zA-Z][a-zA-Z0-9+.\-]*)://", str(url))
+    if not m:
+        return
+    scheme = m.group(1).lower()
+    inputs, outputs = _get_ffmpeg_protocols()
+    available = inputs if direction == "input" else outputs
+    if not available:
+        return  # detection failed; don't preempt ffmpeg's own error
+    if scheme not in available:
+        _warnings.warn(
+            "ffmpeg at %s does not list %r as a supported %s protocol "
+            "(available: %s). ffmpeg may still try and fail with its own "
+            "error message; if you see a connection-refused or "
+            "protocol-not-found error, rebuild or reinstall ffmpeg with "
+            "support for %r." % (
+                _FFMPEG_PATH, scheme, direction,
+                ", ".join(sorted(available)[:20]) +
+                ("..." if len(available) > 20 else ""),
+                scheme,
+            ),
+            UserWarning,
+        )
+
+
 def scan_libav():
     global _LIBAV_MAJOR_VERSION
     global _LIBAV_MINOR_VERSION
@@ -297,7 +406,12 @@ def setFFmpegPath(path):
     """
     global _FFMPEG_PATH
     global _HAS_FFMPEG
+    global _FFMPEG_INPUT_PROTOCOLS, _FFMPEG_OUTPUT_PROTOCOLS
     _FFMPEG_PATH = path
+    # New binary may have different compiled-in protocol support; clear
+    # the cache so the next URL use re-detects (issue #117 protocol check).
+    _FFMPEG_INPUT_PROTOCOLS = None
+    _FFMPEG_OUTPUT_PROTOCOLS = None
 
     # check to see if the executables actually exist on these paths
     if os.path.isfile(os.path.join(_FFMPEG_PATH, _FFMPEG_APPLICATION)) and os.path.isfile(os.path.join(_FFMPEG_PATH, _FFPROBE_APPLICATION)):

--- a/skvideo/__init__.py
+++ b/skvideo/__init__.py
@@ -436,9 +436,16 @@ def setFFmpegPath(path):
         global _FFMPEG_MAJOR_VERSION
         global _FFMPEG_MINOR_VERSION
         global _FFMPEG_PATCH_VERSION
+        global _FFMPEG_SUPPORTED_DECODERS
+        global _FFMPEG_SUPPORTED_ENCODERS
         _FFMPEG_MAJOR_VERSION = "0"
         _FFMPEG_MINOR_VERSION = "0"
         _FFMPEG_PATCH_VERSION = "0"
+        # Clear codec lists too, otherwise a bad path leaves the module
+        # half-configured: _HAS_FFMPEG=0 but stale decoders/encoders from the
+        # previous valid binary.
+        _FFMPEG_SUPPORTED_DECODERS = []
+        _FFMPEG_SUPPORTED_ENCODERS = []
         return
 
     # reload version from new path

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -9,6 +9,7 @@ import warnings
 import numpy as np
 
 from .. import _HAS_FFMPEG
+from .. import _warn_if_unsupported_protocol
 from ..utils import *
 
 
@@ -156,6 +157,12 @@ class VideoReaderAbstract(object):
             self._temp_input_path = _spool_memory_to_tempfile(filename)
             filename = self._temp_input_path
             self._source_kind = "file"
+        elif self._source_kind == "url":
+            # Warn early if the installed ffmpeg lacks support for this
+            # URL scheme (e.g. https on a build without OpenSSL). The
+            # warning makes ffmpeg's eventual error obvious; we don't
+            # raise because protocol detection is best-effort.
+            _warn_if_unsupported_protocol(filename, "input")
         filename = os.fspath(filename)
         self._filename = filename
         self.verbosity = verbosity
@@ -566,6 +573,7 @@ class VideoWriterAbstract(object):
             # URL output: ffmpeg picks the format from the URL itself
             # (e.g. rtmp://... → FLV) or from -f in outputdict. Skip the
             # extension allowlist and the writable-directory check.
+            _warn_if_unsupported_protocol(filename, "output")
             self.extension = ""
             self._filename = filename
         else:

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -101,7 +101,11 @@ class VideoReaderAbstract(object):
         # check if FFMPEG exists in the path
         assert _HAS_FFMPEG, "Cannot find installation of real FFmpeg (which comes with ffprobe)."
 
-        filename = os.fspath(filename)
+        self._source_kind = _classify_source(filename)
+        # Only run os.fspath when we have a path-like — file-like objects
+        # don't implement __fspath__ and must keep their original identity.
+        if self._source_kind != "memory":
+            filename = os.fspath(filename)
         self._filename = filename
         self.verbosity = verbosity
 
@@ -111,9 +115,17 @@ class VideoReaderAbstract(object):
         if not outputdict:
             outputdict = {}
 
-        # General information
-        _, self.extension = os.path.splitext(filename)
-        self.size = os.path.getsize(filename)
+        # General information. Filesystem ops are file-only — URLs and memory
+        # sources skip them. ffmpeg/ffprobe handle URLs natively (note: probing
+        # a remote URL incurs network latency on FFmpegReader construction).
+        if self._source_kind == "file":
+            _, self.extension = os.path.splitext(filename)
+            self.size = os.path.getsize(filename)
+        else:
+            # URLs don't have a meaningful filesystem extension; use empty so
+            # downstream checks (which mostly gate on .yuv / .raw) skip cleanly.
+            self.extension = ""
+            self.size = 0
         self.probeInfo = self._probe()
 
         # smartphone video data is weird
@@ -208,7 +220,16 @@ class VideoReaderAbstract(object):
         self.bpp = int(bpplut[self.pix_fmt][1])
 
         israw = str.encode(self.extension) in [b".raw", b".yuv"]
-        iswebcam = not os.path.isfile(filename)
+        # iswebcam covers cases where input has no finite frame count (live
+        # device, streaming URL). The os.path.isfile heuristic still routes
+        # /dev/video* and similar to this branch; URLs and memory sources are
+        # detected via _source_kind so we don't re-hit a filesystem call.
+        if self._source_kind == "file":
+            iswebcam = not os.path.isfile(filename)
+        else:
+            # URL: treat as a stream unless the metadata gave us a frame count.
+            # Memory (BytesIO): finite by construction, so not a webcam.
+            iswebcam = (self._source_kind == "url") and (self.INFO_NB_FRAMES not in viddict)
 
         if ("-vframes" in outputdict):
             self.inputframenum = int(outputdict["-vframes"])
@@ -223,7 +244,8 @@ class VideoReaderAbstract(object):
             # we can compute it based on the input size and color space
             self.inputframenum = int(self.size / (self.inputwidth * self.inputheight * (self.bpp / 8.0)))
         elif iswebcam:
-            # webcam can stream frames endlessly, lets use the special default value of 0 to indicate that
+            # webcam (or live URL) can stream frames endlessly, lets use the
+            # special default value of 0 to indicate that
             self.inputframenum = 0
         else:
             self.inputframenum = self._probCountFrames()
@@ -240,6 +262,12 @@ class VideoReaderAbstract(object):
 
         if israw or iswebcam:
             inputdict['-pix_fmt'] = self.pix_fmt
+        elif self._source_kind != "file":
+            # URL / BytesIO: ffprobe already told us the codec; the
+            # extension-based sanity check doesn't apply (and the extension
+            # itself is meaningless for these sources). Trust ffmpeg to
+            # surface a decode error if it can't handle the input.
+            pass
         else:
             decoders = self._getSupportedDecoders()
             if decoders != NotImplemented:

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -536,20 +536,41 @@ class VideoWriterAbstract(object):
         """
         self.DEVNULL = open(os.devnull, 'wb')
 
-        filename = os.path.abspath(os.fspath(filename))
-        _, self.extension = os.path.splitext(filename)
+        # Classify the output destination so we can skip filesystem-only
+        # operations (os.path.abspath, os.access W_OK) for URL outputs like
+        # rtmp:// or http:// PUT targets. ffmpeg handles the network side
+        # natively; the wrapper just needs to get out of its way (issue #117
+        # write-side, related #81).
+        self._dest_kind = _classify_source(filename)
 
-        # check that the extension makes sense
-        encoders = self._getSupportedEncoders()
-        if encoders != NotImplemented:
-            assert str.encode(
-                self.extension).lower() in encoders, "Unknown encoder extension: " + self.extension.lower()
+        if self._dest_kind == "file":
+            filename = os.path.abspath(os.fspath(filename))
+            _, self.extension = os.path.splitext(filename)
+            # check that the extension makes sense
+            encoders = self._getSupportedEncoders()
+            if encoders != NotImplemented:
+                assert str.encode(
+                    self.extension).lower() in encoders, "Unknown encoder extension: " + self.extension.lower()
 
-        self._filename = filename
-        basepath, _ = os.path.split(filename)
+            self._filename = filename
+            basepath, _ = os.path.split(filename)
 
-        # check to see if filename is a valid file location
-        assert os.access(basepath, os.W_OK), "Cannot write to directory: " + basepath
+            # check to see if filename is a valid file location
+            assert os.access(basepath, os.W_OK), "Cannot write to directory: " + basepath
+        elif self._dest_kind == "url":
+            # URL output: ffmpeg picks the format from the URL itself
+            # (e.g. rtmp://... → FLV) or from -f in outputdict. Skip the
+            # extension allowlist and the writable-directory check.
+            self.extension = ""
+            self._filename = filename
+        else:
+            # Memory destination (BytesIO/file-like): commit 5 wires this up.
+            # Refuse cleanly here so users on this v1.1.14 commit see an
+            # informative error rather than a downstream crash.
+            raise NotImplementedError(
+                "Writing to a BytesIO / file-like object is not yet supported. "
+                "Use a file path or URL for now."
+            )
 
         if not inputdict:
             inputdict = {}

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -2,6 +2,7 @@ import io
 import os
 import re
 import tempfile
+import threading
 import time
 import warnings
 
@@ -542,6 +543,10 @@ class VideoWriterAbstract(object):
         # natively; the wrapper just needs to get out of its way (issue #117
         # write-side, related #81).
         self._dest_kind = _classify_source(filename)
+        # Always-defined fields; the memory branch below may overwrite.
+        self._memory_dest = None
+        self._stdout_drain_thread = None
+        self._stdout_drain_error = None
 
         if self._dest_kind == "file":
             filename = os.path.abspath(os.fspath(filename))
@@ -564,13 +569,20 @@ class VideoWriterAbstract(object):
             self.extension = ""
             self._filename = filename
         else:
-            # Memory destination (BytesIO/file-like): commit 5 wires this up.
-            # Refuse cleanly here so users on this v1.1.14 commit see an
-            # informative error rather than a downstream crash.
-            raise NotImplementedError(
-                "Writing to a BytesIO / file-like object is not yet supported. "
-                "Use a file path or URL for now."
-            )
+            # Memory destination (BytesIO/file-like with .write). ffmpeg
+            # writes encoded bytes to stdout (pipe:1); a background thread
+            # drains stdout into the user's buffer so ffmpeg never blocks on
+            # a full pipe (issue #113 write-side).
+            if not hasattr(filename, "write"):
+                raise TypeError(
+                    "Memory destination must be a file-like object with a "
+                    "write() method (e.g. io.BytesIO()); got %r" % type(filename)
+                )
+            self._memory_dest = filename
+            self._stdout_drain_thread = None
+            self._stdout_drain_error = None
+            self.extension = ""
+            self._filename = "pipe:1"  # ffmpeg writes encoded bytes to stdout
 
         if not inputdict:
             inputdict = {}
@@ -584,6 +596,23 @@ class VideoWriterAbstract(object):
 
         if "-f" not in self.inputdict:
             self.inputdict["-f"] = "rawvideo"
+
+        # For memory destinations, ffmpeg writes to stdout which is not
+        # seekable. Apply streaming-friendly defaults if the caller didn't
+        # already specify them (issue #113 write-side):
+        #   -f mp4: pick a container; without this, ffmpeg can't infer
+        #     format from the "pipe:1" pseudo-filename
+        #   -movflags frag_keyframe+empty_moov: write a fragmented mp4 so
+        #     the moov atom appears up-front instead of requiring a seek
+        #     back to the start at end-of-encode (which would fail on a pipe).
+        # If the caller chose a different format (webm, matroska, mpegts, …),
+        # we trust them to know it's streamable.
+        if self._dest_kind == "memory":
+            if "-f" not in self.outputdict:
+                self.outputdict["-f"] = "mp4"
+            if self.outputdict.get("-f") == "mp4" and "-movflags" not in self.outputdict:
+                self.outputdict["-movflags"] = "frag_keyframe+empty_moov"
+
         self.warmStarted = False
         self._proc = None
 
@@ -668,6 +697,36 @@ class VideoWriterAbstract(object):
     def _prepareData(self, data):
         return data  # general case : do nothing
 
+    def _start_stdout_drain_thread(self):
+        """Drain ffmpeg stdout into ``self._memory_dest`` in a background thread.
+
+        Used only for memory destinations (issue #113 write-side). The
+        thread reads stdout in 64KB chunks until EOF, copies each chunk
+        into the user's buffer, and stores any exception in
+        ``self._stdout_drain_error`` so ``close()`` can re-raise it from
+        the main thread.
+
+        Without continuous draining, ffmpeg would block once stdout's
+        ~64KB pipe buffer filled — deadlocking the writer.
+        """
+        stdout = self._proc.stdout
+        dest = self._memory_dest
+
+        def _drain():
+            try:
+                while True:
+                    chunk = stdout.read(64 * 1024)
+                    if not chunk:
+                        break
+                    dest.write(chunk)
+            except Exception as exc:
+                self._stdout_drain_error = exc
+
+        self._stdout_drain_thread = threading.Thread(
+            target=_drain, daemon=True, name="skvideo-stdout-drain"
+        )
+        self._stdout_drain_thread.start()
+
     def close(self):
         """Closes the video and terminates FFmpeg process
 
@@ -680,12 +739,47 @@ class VideoWriterAbstract(object):
             return  # no process
         if self._proc.poll() is not None:
             return  # process already dead
-        # communicate() closes stdin, then drains stdout/stderr while
-        # waiting — this avoids the deadlock that wait() would hit if
-        # FFmpeg's stderr pipe filled. When stderr is None (verbosity>0),
-        # the second tuple element is None and we have nothing to surface.
-        # Don't call stdin.close() ourselves first: communicate() flushes
-        # stdin and raises ValueError if it's already closed.
+
+        if self._dest_kind == "memory":
+            # Memory destination: stdout is owned by the drain thread. We
+            # close stdin to tell ffmpeg "no more frames", wait for ffmpeg
+            # to flush + exit, then join the drain thread to be sure the
+            # last bytes landed in the user's buffer. communicate() can't
+            # be used here because it would also try to read stdout.
+            if self._proc.stdin and not self._proc.stdin.closed:
+                self._proc.stdin.close()
+            self._proc.wait()
+            if self._stdout_drain_thread is not None:
+                self._stdout_drain_thread.join(timeout=30)
+            stderr_data = b""
+            if self._proc.stderr is not None:
+                try:
+                    stderr_data = self._proc.stderr.read() or b""
+                except Exception:
+                    pass
+            returncode = self._proc.returncode
+            self._proc = None
+            self.DEVNULL.close()
+            if self._stdout_drain_error is not None:
+                # The drain thread crashed; surface that ahead of the
+                # ffmpeg exit code, which is likely a side effect.
+                raise RuntimeError(
+                    "BytesIO destination write failed: %r" % self._stdout_drain_error
+                )
+            if returncode != 0:
+                msg = "FFmpeg exited with code %d" % returncode
+                if stderr_data:
+                    msg += ":\n" + stderr_data.decode(errors='replace')
+                raise RuntimeError(msg)
+            return
+
+        # File / URL destination: communicate() closes stdin, then drains
+        # stdout/stderr while waiting — this avoids the deadlock that
+        # wait() would hit if FFmpeg's stderr pipe filled. When stderr is
+        # None (verbosity>0), the second tuple element is None and we have
+        # nothing to surface. Don't call stdin.close() ourselves first:
+        # communicate() flushes stdin and raises ValueError if it's
+        # already closed.
         _, stderr_data = self._proc.communicate()
         returncode = self._proc.returncode
         self._proc = None

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -1,6 +1,7 @@
 import io
 import os
 import re
+import tempfile
 import time
 import warnings
 
@@ -43,6 +44,46 @@ def _classify_source(source):
     if _URL_SCHEME_RE.match(source_str):
         return "url"
     return "file"
+
+
+def _spool_memory_to_tempfile(source):
+    """Copy a file-like ``source`` into a NamedTemporaryFile and return its path.
+
+    Called when the reader's input is a BytesIO or other file-like (issue
+    #113). Container formats like mp4 need random access to read header
+    atoms that live at the end of the file, which subprocess stdin can't
+    reliably provide. Spooling to disk lets the rest of the read path
+    treat the source uniformly with a regular filename.
+
+    The temp file is created with ``delete=False``; the caller (typically
+    ``VideoReaderAbstract.close``) is responsible for unlinking it. If the
+    source has a ``.name`` attribute with a recognizable extension, that
+    extension is preserved on the temp file; otherwise ``.mp4`` is used
+    as a sensible default (ffmpeg always content-detects format regardless
+    of extension, but our wrapper's extension-based decoder-allowlist check
+    needs *some* valid extension).
+    """
+    if hasattr(source, "seek"):
+        source.seek(0)
+    suffix = ".mp4"
+    name = getattr(source, "name", None)
+    if isinstance(name, str):
+        _, ext = os.path.splitext(name)
+        if ext:
+            suffix = ext
+    tf = tempfile.NamedTemporaryFile(
+        prefix="skvideo_in_", suffix=suffix, delete=False
+    )
+    try:
+        # Stream-copy in chunks so we don't materialize huge buffers.
+        while True:
+            chunk = source.read(1024 * 1024)
+            if not chunk:
+                break
+            tf.write(chunk)
+    finally:
+        tf.close()
+    return tf.name
 
 
 class VideoReaderAbstract(object):
@@ -102,10 +143,19 @@ class VideoReaderAbstract(object):
         assert _HAS_FFMPEG, "Cannot find installation of real FFmpeg (which comes with ffprobe)."
 
         self._source_kind = _classify_source(filename)
-        # Only run os.fspath when we have a path-like — file-like objects
-        # don't implement __fspath__ and must keep their original identity.
-        if self._source_kind != "memory":
-            filename = os.fspath(filename)
+        # Track temp files spooled from memory sources so close() can clean
+        # them up. None for file / url sources.
+        self._temp_input_path = None
+        # Memory sources (BytesIO, file-like): spool to a temp file so the
+        # rest of __init__ — ffprobe, extension heuristics, frame reading —
+        # can operate on a regular path. mp4's moov atom in particular
+        # needs random access that subprocess stdin can't provide reliably.
+        # After spooling, treat as a file for all downstream branching.
+        if self._source_kind == "memory":
+            self._temp_input_path = _spool_memory_to_tempfile(filename)
+            filename = self._temp_input_path
+            self._source_kind = "file"
+        filename = os.fspath(filename)
         self._filename = filename
         self.verbosity = verbosity
 
@@ -363,6 +413,14 @@ class VideoReaderAbstract(object):
                 self._proc.stderr.close()
             self._terminate(0.2)
         self._proc = None
+        # Clean up the spooled temp file for memory sources (issue #113).
+        # Best-effort: ignore if already removed or unreachable.
+        if self._temp_input_path is not None:
+            try:
+                os.unlink(self._temp_input_path)
+            except OSError:
+                pass
+            self._temp_input_path = None
 
     def _terminate(self, timeout=1.0):
         """ Terminate the sub process.

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -145,8 +145,9 @@ class VideoReaderAbstract(object):
             pass ``outputdict={"-vf": "select='gte(n\\\\,N)'", "-vsync":
             "0"}`` instead (``-vf`` is an output filter, so it must go in
             ``outputdict``; ``-vsync 0`` stops FFmpeg from re-padding the
-            dropped frames back to a constant rate). That is slower because
-            it decodes from the start of the file.
+            dropped frames back to a constant rate, and on FFmpeg 5.1+ is
+            equivalent to ``-fps_mode passthrough``). That is slower
+            because it decodes from the start of the file.
 
         Returns
         -------

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -83,8 +83,17 @@ def _spool_memory_to_tempfile(source):
             if not chunk:
                 break
             tf.write(chunk)
-    finally:
+    except BaseException:
+        # The copy failed partway (e.g. source.read raised). The temp file
+        # is already on disk with delete=False, so unlink it here before
+        # re-raising — the caller never gets a path and can't clean up.
         tf.close()
+        try:
+            os.unlink(tf.name)
+        except OSError:
+            pass
+        raise
+    tf.close()
     return tf.name
 
 
@@ -133,7 +142,8 @@ class VideoReaderAbstract(object):
             so the actual first frame returned may snap to the nearest
             keyframe at or before the requested position. Combine with
             ``num_frames`` for a windowed read. For frame-exact extraction,
-            pass ``inputdict={"-vf": "select='gte(n\\\\,N)'"}`` instead;
+            pass ``outputdict={"-vf": "select='gte(n\\\\,N)'"}`` instead
+            (``-vf`` is an output filter, so it must go in ``outputdict``);
             that is slower because it decodes from the start of the file.
 
         Returns
@@ -154,6 +164,12 @@ class VideoReaderAbstract(object):
         # needs random access that subprocess stdin can't provide reliably.
         # After spooling, treat as a file for all downstream branching.
         if self._source_kind == "memory":
+            if not hasattr(filename, "read"):
+                raise TypeError(
+                    "Input source is a file-like object without a read() "
+                    "method; FFmpegReader needs a readable source (got %r)."
+                    % type(filename)
+                )
             self._temp_input_path = _spool_memory_to_tempfile(filename)
             filename = self._temp_input_path
             self._source_kind = "file"
@@ -169,7 +185,7 @@ class VideoReaderAbstract(object):
         # missing width/height, decoder mismatch) unlinks the spooled temp
         # file before re-raising. Without this, callers never get a
         # reference to the half-constructed reader, so close() is
-        # unreachable and the temp file leaks (Codex round 1 finding).
+        # unreachable and the temp file leaks.
         try:
             self._finish_init(filename, inputdict, outputdict, verbosity, start_frame)
         except Exception:
@@ -185,7 +201,7 @@ class VideoReaderAbstract(object):
         """The rest of __init__, wrapped so spool failure cleanup can apply.
 
         Extracted purely for the try/except boundary; semantics are
-        unchanged from doing this work inline (Codex round 1: temp-leak fix).
+        unchanged from doing this work inline.
         """
         self._filename = filename
         self.verbosity = verbosity
@@ -770,10 +786,20 @@ class VideoWriterAbstract(object):
         #111). Previously a failing encode produced a silent empty/corrupt
         output file with no indication of what went wrong.
         """
-        if self._proc is None:  # pragma: no cover
-            return  # no process
+        if self._proc is None:
+            # Writer was constructed but never warm-started (no frames
+            # written), e.g. URL/parameter validation paths. The FFmpeg
+            # subprocess was never launched, but DEVNULL was opened in
+            # __init__, so release it here to avoid leaking the fd.
+            if self.DEVNULL is not None and not self.DEVNULL.closed:
+                self.DEVNULL.close()
+            return
         if self._proc.poll() is not None:
-            return  # process already dead
+            # Process already exited; release DEVNULL and drop the handle.
+            self._proc = None
+            if self.DEVNULL is not None and not self.DEVNULL.closed:
+                self.DEVNULL.close()
+            return
 
         if self._dest_kind == "memory":
             # Memory destination: stdout is owned by the drain thread. We

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -383,8 +383,8 @@ class VideoReaderAbstract(object):
             decoders = self._getSupportedDecoders()
             if decoders != NotImplemented:
                 # check that the extension makes sense
-                assert str.encode(
-                    self.extension).lower() in decoders, "Unknown decoder extension: " + self.extension.lower()
+                if str.encode(self.extension).lower() not in decoders:
+                    raise ValueError("Unknown decoder extension: " + self.extension.lower())
 
         if '-f' not in outputdict:
             outputdict['-f'] = self.OUTPUT_METHOD
@@ -614,14 +614,15 @@ class VideoWriterAbstract(object):
             # check that the extension makes sense
             encoders = self._getSupportedEncoders()
             if encoders != NotImplemented:
-                assert str.encode(
-                    self.extension).lower() in encoders, "Unknown encoder extension: " + self.extension.lower()
+                if str.encode(self.extension).lower() not in encoders:
+                    raise ValueError("Unknown encoder extension: " + self.extension.lower())
 
             self._filename = filename
             basepath, _ = os.path.split(filename)
 
             # check to see if filename is a valid file location
-            assert os.access(basepath, os.W_OK), "Cannot write to directory: " + basepath
+            if not os.access(basepath, os.W_OK):
+                raise OSError("Cannot write to directory: " + basepath)
         elif self._dest_kind == "url":
             # URL output: ffmpeg picks the format from the URL itself
             # (e.g. rtmp://... → FLV) or from -f in outputdict. Skip the
@@ -730,8 +731,9 @@ class VideoWriterAbstract(object):
         else:
             raise ValueError(self.inputdict['-pix_fmt'] + 'is not a valid pix_fmt for numpy conversion')
 
-        assert self.inputNumChannels == C, "Failed to pass the correct number of channels %d for the pixel format %s." % (
-            self.inputNumChannels, self.inputdict["-pix_fmt"])
+        if self.inputNumChannels != C:
+            raise ValueError("Failed to pass the correct number of channels %d for the pixel format %s." % (
+                self.inputNumChannels, self.inputdict["-pix_fmt"]))
 
         if ("-s" in self.inputdict):
             widthheight = self.inputdict["-s"].split('x')

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -1,4 +1,6 @@
+import io
 import os
+import re
 import time
 import warnings
 
@@ -6,6 +8,41 @@ import numpy as np
 
 from .. import _HAS_FFMPEG
 from ..utils import *
+
+
+# Matches URL schemes ffmpeg supports for input/output (http, https, rtsp, rtmp,
+# rtmps, udp, tcp, ftp, sftp, srt, unix, file, pipe, concat, async, hls, ...).
+# We classify any string that looks like `<scheme>://<...>` as a URL and let
+# ffmpeg validate the specific protocol.
+_URL_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.\-]*://")
+
+
+def _classify_source(source):
+    """Classify an input/output source into one of three kinds.
+
+    Returns one of ``"file"``, ``"url"``, ``"memory"``. Used by the reader and
+    writer to dispatch around filesystem-only operations like ``os.path.getsize``,
+    ``os.path.isfile``, and ``os.access(..., os.W_OK)`` (issue #117, #113, #81).
+
+    - ``str`` or ``Path`` matching ``<scheme>://...`` → ``"url"``
+    - ``BytesIO`` or any object with a ``read`` / ``write`` method → ``"memory"``
+    - everything else → ``"file"`` (the existing behavior)
+
+    A pure string filename like ``"video.mp4"`` is classified as ``"file"``; the
+    URL check is intentionally strict (``://`` required) so Windows drive
+    letters and oddly-named local files don't false-positive.
+    """
+    # File-like / BytesIO objects expose read or write
+    if hasattr(source, "read") or hasattr(source, "write"):
+        return "memory"
+    # os.fspath() turns Path into str without changing strings
+    try:
+        source_str = os.fspath(source)
+    except TypeError:
+        return "file"  # fallback; downstream will surface the real error
+    if _URL_SCHEME_RE.match(source_str):
+        return "url"
+    return "file"
 
 
 class VideoReaderAbstract(object):

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -142,9 +142,11 @@ class VideoReaderAbstract(object):
             so the actual first frame returned may snap to the nearest
             keyframe at or before the requested position. Combine with
             ``num_frames`` for a windowed read. For frame-exact extraction,
-            pass ``outputdict={"-vf": "select='gte(n\\\\,N)'"}`` instead
-            (``-vf`` is an output filter, so it must go in ``outputdict``);
-            that is slower because it decodes from the start of the file.
+            pass ``outputdict={"-vf": "select='gte(n\\\\,N)'", "-vsync":
+            "0"}`` instead (``-vf`` is an output filter, so it must go in
+            ``outputdict``; ``-vsync 0`` stops FFmpeg from re-padding the
+            dropped frames back to a constant rate). That is slower because
+            it decodes from the start of the file.
 
         Returns
         -------
@@ -164,10 +166,17 @@ class VideoReaderAbstract(object):
         # needs random access that subprocess stdin can't provide reliably.
         # After spooling, treat as a file for all downstream branching.
         if self._source_kind == "memory":
-            if not hasattr(filename, "read"):
+            # Must be readable. hasattr("read") alone is too weak: a file
+            # opened in write mode ("wb") still exposes a read attribute
+            # that raises io.UnsupportedOperation when called. Prefer the
+            # readable() probe when the object provides it, and require a
+            # callable read otherwise.
+            read = getattr(filename, "read", None)
+            readable = getattr(filename, "readable", None)
+            if not callable(read) or (callable(readable) and not readable()):
                 raise TypeError(
-                    "Input source is a file-like object without a read() "
-                    "method; FFmpegReader needs a readable source (got %r)."
+                    "Input source is not readable; FFmpegReader needs a "
+                    "file-like object opened for reading (got %r)."
                     % type(filename)
                 )
             self._temp_input_path = _spool_memory_to_tempfile(filename)

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -830,6 +830,16 @@ class VideoWriterAbstract(object):
                     stderr_data = self._proc.stderr.read() or b""
                 except Exception:
                     pass
+            # Close the subprocess pipe objects explicitly. The drain thread
+            # reads stdout to EOF but doesn't close the file object, and we've
+            # just finished reading stderr; without this, Popen leaves them to
+            # be reclaimed at GC and Python emits ResourceWarning per writer.
+            for pipe in (self._proc.stdout, self._proc.stderr):
+                if pipe is not None and not pipe.closed:
+                    try:
+                        pipe.close()
+                    except Exception:
+                        pass
             returncode = self._proc.returncode
             self._proc = None
             self.DEVNULL.close()

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -196,15 +196,17 @@ class VideoReaderAbstract(object):
         if not outputdict:
             outputdict = {}
 
-        # General information. Filesystem ops are file-only — URLs and memory
-        # sources skip them. ffmpeg/ffprobe handle URLs natively (note: probing
-        # a remote URL incurs network latency on FFmpegReader construction).
+        # General information. URLs skip filesystem ops entirely; memory
+        # sources reach here as "file" because we already spooled them to
+        # a real temp path above. ffmpeg/ffprobe handle URLs natively
+        # (note: probing a remote URL incurs network latency on
+        # FFmpegReader construction).
         if self._source_kind == "file":
             _, self.extension = os.path.splitext(filename)
             self.size = os.path.getsize(filename)
         else:
-            # URLs don't have a meaningful filesystem extension; use empty so
-            # downstream checks (which mostly gate on .yuv / .raw) skip cleanly.
+            # URL: no meaningful filesystem extension; use empty so downstream
+            # checks (which mostly gate on .yuv / .raw) skip cleanly.
             self.extension = ""
             self.size = 0
         self.probeInfo = self._probe()
@@ -303,14 +305,15 @@ class VideoReaderAbstract(object):
         israw = str.encode(self.extension) in [b".raw", b".yuv"]
         # iswebcam covers cases where input has no finite frame count (live
         # device, streaming URL). The os.path.isfile heuristic still routes
-        # /dev/video* and similar to this branch; URLs and memory sources are
-        # detected via _source_kind so we don't re-hit a filesystem call.
+        # /dev/video* and similar to this branch. Memory sources have
+        # already been spooled to a temp file path above, so they take the
+        # file branch with isfile==True. URLs need explicit handling.
         if self._source_kind == "file":
             iswebcam = not os.path.isfile(filename)
         else:
-            # URL: treat as a stream unless the metadata gave us a frame count.
-            # Memory (BytesIO): finite by construction, so not a webcam.
-            iswebcam = (self._source_kind == "url") and (self.INFO_NB_FRAMES not in viddict)
+            # URL: treat as a stream unless the metadata gave us a frame
+            # count (e.g. mp4 over http reports nb_frames).
+            iswebcam = self.INFO_NB_FRAMES not in viddict
 
         if ("-vframes" in outputdict):
             self.inputframenum = int(outputdict["-vframes"])
@@ -344,10 +347,11 @@ class VideoReaderAbstract(object):
         if israw or iswebcam:
             inputdict['-pix_fmt'] = self.pix_fmt
         elif self._source_kind != "file":
-            # URL / BytesIO: ffprobe already told us the codec; the
-            # extension-based sanity check doesn't apply (and the extension
-            # itself is meaningless for these sources). Trust ffmpeg to
-            # surface a decode error if it can't handle the input.
+            # URL: ffprobe already validated the codec; the wrapper's
+            # extension-based sanity check has no extension to check
+            # against. Trust ffmpeg to surface a decode error if it can't
+            # handle the input. (Memory inputs reach here as "file" via
+            # the temp-spool path, so they DO get the assert below.)
             pass
         else:
             decoders = self._getSupportedDecoders()

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -164,6 +164,29 @@ class VideoReaderAbstract(object):
             # raise because protocol detection is best-effort.
             _warn_if_unsupported_protocol(filename, "input")
         filename = os.fspath(filename)
+
+        # Wrap the rest of __init__ so that any failure (bad ffprobe,
+        # missing width/height, decoder mismatch) unlinks the spooled temp
+        # file before re-raising. Without this, callers never get a
+        # reference to the half-constructed reader, so close() is
+        # unreachable and the temp file leaks (Codex round 1 finding).
+        try:
+            self._finish_init(filename, inputdict, outputdict, verbosity, start_frame)
+        except Exception:
+            if self._temp_input_path is not None:
+                try:
+                    os.unlink(self._temp_input_path)
+                except OSError:
+                    pass
+                self._temp_input_path = None
+            raise
+
+    def _finish_init(self, filename, inputdict, outputdict, verbosity, start_frame):
+        """The rest of __init__, wrapped so spool failure cleanup can apply.
+
+        Extracted purely for the try/except boundary; semantics are
+        unchanged from doing this work inline (Codex round 1: temp-leak fix).
+        """
         self._filename = filename
         self.verbosity = verbosity
 

--- a/skvideo/io/avprobe.py
+++ b/skvideo/io/avprobe.py
@@ -1,4 +1,5 @@
 import subprocess as sp
+import warnings
 
 from ..utils import *
 from .. import _HAS_AVCONV, _LIBAV_MAJOR_VERSION
@@ -48,5 +49,12 @@ def avprobe(filename):
             streamsbytype[d["codec_type"].lower()] = d
 
         return streamsbytype
-    except:
+    except Exception as exc:
+        warnings.warn(
+            "avprobe could not parse %r (%s); returning empty metadata. "
+            "Expected for raw video (supply stream parameters via inputdict); "
+            "for a normal media file this usually means it is unreadable or "
+            "not a recognized format." % (filename, exc),
+            UserWarning,
+        )
         return {}

--- a/skvideo/io/ffmpeg.py
+++ b/skvideo/io/ffmpeg.py
@@ -194,7 +194,16 @@ class FFmpegWriter(VideoWriterAbstract):
         # writeFrame IOError handler can surface FFmpeg's actual error output
         # (issue #111). verbosity>0 leaves stderr unredirected so the user
         # sees FFmpeg's output live and we have no captured stream to read.
-        if self.verbosity > 0:
+        # For memory destinations, stdout MUST be a PIPE (regardless of
+        # verbosity) because ffmpeg writes the encoded bytes there and a
+        # background thread drains them into the user's buffer (issue #113
+        # write-side). Without draining, ffmpeg blocks once stdout's
+        # ~64KB pipe buffer fills.
+        if self._dest_kind == "memory":
+            self._proc = sp.Popen(cmd, stdin=sp.PIPE,
+                                  stdout=sp.PIPE, stderr=sp.PIPE)
+            self._start_stdout_drain_thread()
+        elif self.verbosity > 0:
             print(self._cmd)
             self._proc = sp.Popen(cmd, stdin=sp.PIPE,
                                   stdout=sp.PIPE, stderr=None)

--- a/skvideo/io/ffmpeg.py
+++ b/skvideo/io/ffmpeg.py
@@ -126,6 +126,15 @@ class FFmpegWriter(VideoWriterAbstract):
 
     verbosity : int
         0 (default) for quiet, 1 to print the ffmpeg command.
+
+    Notes
+    -----
+    The FFmpeg subprocess is launched lazily on the first ``writeFrame``
+    call. Constructing a writer and calling ``close()`` without writing any
+    frames is a no-op and produces no output file — this keeps cleanup in a
+    ``finally`` (or a construct-only validation) from raising. Use the
+    high-level ``skvideo.io.vwrite``, which rejects empty (0-frame) input
+    with ``ValueError``, if you want that guarded.
     """
 
     def __init__(self, filename, inputdict=None, outputdict=None,

--- a/skvideo/io/ffprobe.py
+++ b/skvideo/io/ffprobe.py
@@ -1,5 +1,6 @@
 import os
 import subprocess as sp
+import warnings
 
 from ..utils import *
 from .. import _HAS_FFMPEG
@@ -70,5 +71,18 @@ def ffprobe(filename):
             result.setdefault(codec_type + "_streams", []).append(stream)
 
         return result
-    except Exception:
+    except Exception as exc:
+        # Returning {} is load-bearing: raw/headerless video (e.g. .yuv) has
+        # no probeable streams and the reader falls back to inputdict's
+        # -s / -pix_fmt. But silently swallowing every failure also hides a
+        # genuinely unreadable/corrupt file behind a later "No way to
+        # determine width or height" error. Warn with the cause so the real
+        # reason is visible, then preserve the {} fallback.
+        warnings.warn(
+            "ffprobe could not parse %r (%s); returning empty metadata. "
+            "Expected for raw video (supply -s and -pix_fmt via inputdict); "
+            "for a normal media file this usually means it is unreadable or "
+            "not a recognized format." % (filename, exc),
+            UserWarning,
+        )
         return {}

--- a/skvideo/io/io.py
+++ b/skvideo/io/io.py
@@ -2,6 +2,7 @@ import os
 
 import numpy as np
 
+from .abstract import _classify_source
 from .avconv import LibAVReader
 from .avconv import LibAVWriter
 from .ffmpeg import FFmpegReader
@@ -9,6 +10,18 @@ from .ffmpeg import FFmpegWriter
 from .. import _HAS_AVCONV
 from .. import _HAS_FFMPEG
 from ..utils import *
+
+
+def _normalize_source(fname):
+    """Path-likes go through os.fspath; file-like objects pass through unchanged.
+
+    Callers downstream (the Reader/Writer constructors) handle the BytesIO /
+    file-like case via _classify_source + spool_memory_to_tempfile, so we
+    must not try to coerce these into strings here.
+    """
+    if _classify_source(fname) == "memory":
+        return fname
+    return os.fspath(fname)
 
 
 def vwrite(fname, videodata, inputdict=None, outputdict=None, backend='ffmpeg', verbosity=0, audiosrc=None):
@@ -51,7 +64,7 @@ def vwrite(fname, videodata, inputdict=None, outputdict=None, backend='ffmpeg', 
     none
 
     """
-    fname = os.fspath(fname)
+    fname = _normalize_source(fname)
 
     if not inputdict:
         inputdict = {}
@@ -141,7 +154,7 @@ def vread(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=None,
         width, and C is depth.
 
     """
-    fname = os.fspath(fname)
+    fname = _normalize_source(fname)
 
     if not inputdict:
         inputdict = {}
@@ -255,7 +268,7 @@ def vreader(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=Non
         Passed to the given plugin.
 
     """
-    fname = os.fspath(fname)
+    fname = _normalize_source(fname)
 
     if not inputdict:
         inputdict = {}

--- a/skvideo/io/io.py
+++ b/skvideo/io/io.py
@@ -180,8 +180,15 @@ def vread(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=None,
             T, M, N, C = reader.getShape()
 
             videodata = np.empty((T, M, N, C), dtype=reader.dtype)
+            count = 0
             for idx, frame in enumerate(reader.nextFrame()):
                 videodata[idx, :, :, :] = frame
+                count = idx + 1
+            # An output filter (e.g. -vf select) can yield fewer frames than
+            # getShape() predicted from nb_frames; trim so the caller never
+            # sees uninitialized np.empty rows.
+            if count < T:
+                videodata = videodata[:count]
 
             if as_grey:
                 videodata = vshape(videodata[:, :, :, 0])
@@ -206,8 +213,12 @@ def vread(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=None,
             T, M, N, C = reader.getShape()
 
             videodata = np.empty((T, M, N, C), dtype=reader.dtype)
+            count = 0
             for idx, frame in enumerate(reader.nextFrame()):
                 videodata[idx, :, :, :] = frame
+                count = idx + 1
+            if count < T:
+                videodata = videodata[:count]
         finally:
             reader.close()
         return videodata

--- a/skvideo/io/io.py
+++ b/skvideo/io/io.py
@@ -77,6 +77,9 @@ def vwrite(fname, videodata, inputdict=None, outputdict=None, backend='ffmpeg', 
     # check that the appropriate videodata size was passed
     T, M, N, C = videodata.shape
 
+    if T == 0:
+        raise ValueError("Cannot write an empty video: videodata has 0 frames.")
+
     if backend == "ffmpeg":
         # check if FFMPEG exists in the path
         assert _HAS_FFMPEG, "Cannot find installation of real FFmpeg (which comes with ffprobe)."

--- a/skvideo/io/io.py
+++ b/skvideo/io/io.py
@@ -176,15 +176,19 @@ def vread(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=None,
             outputdict['-pix_fmt'] = 'gray'
 
         reader = FFmpegReader(fname, inputdict=inputdict, outputdict=outputdict, verbosity=verbosity, start_frame=start_frame)
-        T, M, N, C = reader.getShape()
+        try:
+            T, M, N, C = reader.getShape()
 
-        videodata = np.empty((T, M, N, C), dtype=reader.dtype)
-        for idx, frame in enumerate(reader.nextFrame()):
-            videodata[idx, :, :, :] = frame
+            videodata = np.empty((T, M, N, C), dtype=reader.dtype)
+            for idx, frame in enumerate(reader.nextFrame()):
+                videodata[idx, :, :, :] = frame
 
-        if as_grey:
-            videodata = vshape(videodata[:, :, :, 0])
-        reader.close()
+            if as_grey:
+                videodata = vshape(videodata[:, :, :, 0])
+        finally:
+            # Always close so a spooled temp file (BytesIO input) is unlinked
+            # even if reading raises partway through.
+            reader.close()
 
         return videodata
     elif backend == "libav":
@@ -198,13 +202,14 @@ def vread(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=None,
             outputdict['-vframes'] = str(num_frames)
 
         reader = LibAVReader(fname, inputdict=inputdict, outputdict=outputdict, verbosity=verbosity)
-        T, M, N, C = reader.getShape()
+        try:
+            T, M, N, C = reader.getShape()
 
-        videodata = np.empty((T, M, N, C), dtype=reader.dtype)
-        for idx, frame in enumerate(reader.nextFrame()):
-            videodata[idx, :, :, :] = frame
-
-        reader.close()
+            videodata = np.empty((T, M, N, C), dtype=reader.dtype)
+            for idx, frame in enumerate(reader.nextFrame()):
+                videodata[idx, :, :, :] = frame
+        finally:
+            reader.close()
         return videodata
 
     else:

--- a/skvideo/io/mprobe.py
+++ b/skvideo/io/mprobe.py
@@ -1,4 +1,5 @@
 import subprocess as sp
+import warnings
 
 from ..utils import *
 from .. import _HAS_MEDIAINFO
@@ -59,5 +60,11 @@ def mprobe(filename):
             tracksbytype[unorderedtracks["@type"]] = unorderedtracks
 
         return tracksbytype
-    except:
+    except Exception as exc:
+        warnings.warn(
+            "mediainfo could not parse %r (%s); returning empty metadata. "
+            "This usually means the file is unreadable or not a recognized "
+            "media format." % (filename, exc),
+            UserWarning,
+        )
         return {}

--- a/skvideo/measure/Li3DDCT.py
+++ b/skvideo/measure/Li3DDCT.py
@@ -33,8 +33,10 @@ def Li3DDCT_features(videoData):
 
     T, M, N, C = videoData.shape
 
-    assert C == 1, "called with video having %d channels. Please supply only the luminance channel." % (C,)
-    assert T >= 4, "Only %d input frames. Please supply at least 4" % (T,)
+    if not (C == 1):
+        raise ValueError("called with video having %d channels. Please supply only the luminance channel." % (C,))
+    if not (T >= 4):
+        raise ValueError("Only %d input frames. Please supply at least 4" % (T,))
 
     feats = np.zeros((63*5,), dtype=np.float32)
     newM = np.int32(np.floor(M/4)*4)

--- a/skvideo/measure/Li3DDCT.py
+++ b/skvideo/measure/Li3DDCT.py
@@ -37,10 +37,13 @@ def Li3DDCT_features(videoData):
     assert T >= 4, "Only %d input frames. Please supply at least 4" % (T,)
 
     feats = np.zeros((63*5,), dtype=np.float32)
-    newM = int32(np.floor(M/4)*4)
-    newN = int32(np.floor(N/4)*4)
+    newM = np.int32(np.floor(M/4)*4)
+    newN = np.int32(np.floor(N/4)*4)
 
-    frameSlices = np.arange(0, T-4, 4)
+    # Non-overlapping groups of 4 frames. Stop is T-3 (not T-4) so the last
+    # valid group starting at T-4 is included; with T-4 the final group was
+    # dropped and T==4 produced no groups at all.
+    frameSlices = np.arange(0, T-3, 4)
     Sfeats = np.zeros((len(frameSlices), 63), dtype=np.float32)
     Gammafeats = np.zeros((len(frameSlices), 63), dtype=np.float32)
     Energy1feats = np.zeros((len(frameSlices), 63), dtype=np.float32)

--- a/skvideo/measure/brisque.py
+++ b/skvideo/measure/brisque.py
@@ -56,7 +56,8 @@ def brisque_features(videoData):
 
     T, M, N, C = videoData.shape
 
-    assert C == 1, "brisque_features called with video having %d channels. Please supply only the luminance channel." % (C,)
+    if not (C == 1):
+        raise ValueError("brisque_features called with video having %d channels. Please supply only the luminance channel." % (C,))
 
     feats = np.zeros((T, 36), dtype=np.float32)
     for i in range(T):

--- a/skvideo/measure/mae.py
+++ b/skvideo/measure/mae.py
@@ -32,7 +32,8 @@ def mae(referenceVideoData, distortedVideoData):
     referenceVideoData = vshape(referenceVideoData)
     distortedVideoData = vshape(distortedVideoData)
 
-    assert(referenceVideoData.shape == distortedVideoData.shape)
+    if referenceVideoData.shape != distortedVideoData.shape:
+        raise ValueError("reference and distorted videos must have the same shape; got %s vs %s" % (referenceVideoData.shape, distortedVideoData.shape))
 
     T, M, N, C = referenceVideoData.shape
 

--- a/skvideo/measure/mae.py
+++ b/skvideo/measure/mae.py
@@ -36,7 +36,8 @@ def mae(referenceVideoData, distortedVideoData):
 
     T, M, N, C = referenceVideoData.shape
 
-    assert C == 1, "mae called with videos containing %d channels. Please supply only the luminance channel" % (C,)
+    if not (C == 1):
+        raise ValueError("mae called with videos containing %d channels. Please supply only the luminance channel" % (C,))
 
     scores = np.zeros(T, dtype=np.float32)
     for t in range(T):

--- a/skvideo/measure/mse.py
+++ b/skvideo/measure/mse.py
@@ -32,7 +32,8 @@ def mse(referenceVideoData, distortedVideoData):
     referenceVideoData = vshape(referenceVideoData)
     distortedVideoData = vshape(distortedVideoData)
 
-    assert(referenceVideoData.shape == distortedVideoData.shape)
+    if referenceVideoData.shape != distortedVideoData.shape:
+        raise ValueError("reference and distorted videos must have the same shape; got %s vs %s" % (referenceVideoData.shape, distortedVideoData.shape))
 
     T, M, N, C = referenceVideoData.shape
 

--- a/skvideo/measure/mse.py
+++ b/skvideo/measure/mse.py
@@ -36,7 +36,8 @@ def mse(referenceVideoData, distortedVideoData):
 
     T, M, N, C = referenceVideoData.shape
 
-    assert C == 1, "mse called with videos containing %d channels. Please supply only the luminance channel" % (C,)
+    if not (C == 1):
+        raise ValueError("mse called with videos containing %d channels. Please supply only the luminance channel" % (C,))
 
     scores = np.zeros(T, dtype=np.float32)
     for t in range(T):

--- a/skvideo/measure/msssim.py
+++ b/skvideo/measure/msssim.py
@@ -90,8 +90,10 @@ def msssim(referenceVideoData, distortedVideoData, method='product'):
 
     T, M, N, C = referenceVideoData.shape
 
-    assert C == 1, "MS-SSIM called with videos containing %d channels. Please supply only the luminance channel" % (C,)
-    assert (M >= 176) & (N >= 176), "You supplied a resolution of %dx%d. MS-SSIM can only be used with videos large enough having multiple scales. Please use only with resolutions >= 176x176." % (M, N)
+    if not (C == 1):
+        raise ValueError("MS-SSIM called with videos containing %d channels. Please supply only the luminance channel" % (C,))
+    if not ((M >= 176) & (N >= 176)):
+        raise ValueError("You supplied a resolution of %dx%d. MS-SSIM can only be used with videos large enough having multiple scales. Please use only with resolutions >= 176x176." % (M, N))
 
     scores = np.zeros(T, dtype=np.float32)
     for t in range(T):

--- a/skvideo/measure/msssim.py
+++ b/skvideo/measure/msssim.py
@@ -86,7 +86,8 @@ def msssim(referenceVideoData, distortedVideoData, method='product'):
     referenceVideoData = vshape(referenceVideoData)
     distortedVideoData = vshape(distortedVideoData)
 
-    assert(referenceVideoData.shape == distortedVideoData.shape)
+    if referenceVideoData.shape != distortedVideoData.shape:
+        raise ValueError("reference and distorted videos must have the same shape; got %s vs %s" % (referenceVideoData.shape, distortedVideoData.shape))
 
     T, M, N, C = referenceVideoData.shape
 

--- a/skvideo/measure/niqe.py
+++ b/skvideo/measure/niqe.py
@@ -53,8 +53,10 @@ def extract_on_patches(img, patch_size):
 def _get_patches_generic(img, patch_size, is_train, stride):
     h, w = np.shape(img)
     if h < patch_size or w < patch_size:
-        print("Input image is too small")
-        exit(0)
+        raise ValueError(
+            "Input image (%dx%d) is smaller than the patch size %d."
+            % (h, w, patch_size)
+        )
 
     # ensure that the patch divides evenly into img
     hoffset = (h % patch_size)

--- a/skvideo/measure/niqe.py
+++ b/skvideo/measure/niqe.py
@@ -132,9 +132,12 @@ def niqe(inputVideoData):
 
     T, M, N, C = inputVideoData.shape
 
-    assert C == 1, "niqe called with videos containing %d channels. Please supply only the luminance channel" % (C,)
-    assert M > (patch_size*2+1), "niqe called with small frame size, requires > 192x192 resolution video using current training parameters"
-    assert N > (patch_size*2+1), "niqe called with small frame size, requires > 192x192 resolution video using current training parameters"
+    if not (C == 1):
+        raise ValueError("niqe called with videos containing %d channels. Please supply only the luminance channel" % (C,))
+    if not (M > (patch_size*2+1)):
+        raise ValueError("niqe called with small frame size, requires > 192x192 resolution video using current training parameters")
+    if not (N > (patch_size*2+1)):
+        raise ValueError("niqe called with small frame size, requires > 192x192 resolution video using current training parameters")
 
     niqe_scores = np.zeros(T, dtype=np.float32)
 

--- a/skvideo/measure/psnr.py
+++ b/skvideo/measure/psnr.py
@@ -37,7 +37,8 @@ def psnr(referenceVideoData, distortedVideoData, bitdepth=8):
 
     bitdepth = int(bitdepth)
 
-    assert(referenceVideoData.shape == distortedVideoData.shape)
+    if referenceVideoData.shape != distortedVideoData.shape:
+        raise ValueError("reference and distorted videos must have the same shape; got %s vs %s" % (referenceVideoData.shape, distortedVideoData.shape))
 
     T, M, N, C = referenceVideoData.shape
 

--- a/skvideo/measure/psnr.py
+++ b/skvideo/measure/psnr.py
@@ -41,7 +41,8 @@ def psnr(referenceVideoData, distortedVideoData, bitdepth=8):
 
     T, M, N, C = referenceVideoData.shape
 
-    assert C == 1, "psnr called with videos containing %d channels. Please supply only the luminance channel" % (C,)
+    if not (C == 1):
+        raise ValueError("psnr called with videos containing %d channels. Please supply only the luminance channel" % (C,))
 
     maxvalue = int(2**bitdepth - 1)
     maxsq = maxvalue**2

--- a/skvideo/measure/ssim.py
+++ b/skvideo/measure/ssim.py
@@ -120,7 +120,8 @@ def ssim(referenceVideoData, distortedVideoData, K_1 = 0.01, K_2 = 0.03, bitdept
     referenceVideoData = vshape(referenceVideoData)
     distortedVideoData = vshape(distortedVideoData)
 
-    assert(referenceVideoData.shape == distortedVideoData.shape)
+    if referenceVideoData.shape != distortedVideoData.shape:
+        raise ValueError("reference and distorted videos must have the same shape; got %s vs %s" % (referenceVideoData.shape, distortedVideoData.shape))
 
 
     T, M, N, C = referenceVideoData.shape
@@ -198,7 +199,8 @@ def ssim_full(referenceVideoData, distortedVideoData, K_1 = 0.01, K_2 = 0.03, bi
     referenceVideoData = vshape(referenceVideoData)
     distortedVideoData = vshape(distortedVideoData)
 
-    assert(referenceVideoData.shape == distortedVideoData.shape)
+    if referenceVideoData.shape != distortedVideoData.shape:
+        raise ValueError("reference and distorted videos must have the same shape; got %s vs %s" % (referenceVideoData.shape, distortedVideoData.shape))
 
 
     T, M, N, C = referenceVideoData.shape

--- a/skvideo/measure/ssim.py
+++ b/skvideo/measure/ssim.py
@@ -125,7 +125,8 @@ def ssim(referenceVideoData, distortedVideoData, K_1 = 0.01, K_2 = 0.03, bitdept
 
     T, M, N, C = referenceVideoData.shape
 
-    assert C == 1, "ssim called with videos containing %d channels. Please supply only the luminance channel" % (C,)
+    if not (C == 1):
+        raise ValueError("ssim called with videos containing %d channels. Please supply only the luminance channel" % (C,))
 
     ssim_scores = np.zeros(T, dtype=np.float32)
 
@@ -202,7 +203,8 @@ def ssim_full(referenceVideoData, distortedVideoData, K_1 = 0.01, K_2 = 0.03, bi
 
     T, M, N, C = referenceVideoData.shape
 
-    assert C == 1, "ssim called with videos containing %d channels. Please supply only the luminance channel" % (C,)
+    if not (C == 1):
+        raise ValueError("ssim called with videos containing %d channels. Please supply only the luminance channel" % (C,))
 
     factor = int(np.max((1, np.round(np.min((M, N))/256.0))))
 

--- a/skvideo/measure/strred.py
+++ b/skvideo/measure/strred.py
@@ -121,7 +121,8 @@ def strred(referenceVideoData, distortedVideoData):
     referenceVideoData = vshape(referenceVideoData)
     distortedVideoData = vshape(distortedVideoData)
 
-    assert(referenceVideoData.shape == distortedVideoData.shape)
+    if referenceVideoData.shape != distortedVideoData.shape:
+        raise ValueError("reference and distorted videos must have the same shape; got %s vs %s" % (referenceVideoData.shape, distortedVideoData.shape))
 
     T, M, N, C = referenceVideoData.shape
 

--- a/skvideo/measure/strred.py
+++ b/skvideo/measure/strred.py
@@ -125,7 +125,8 @@ def strred(referenceVideoData, distortedVideoData):
 
     T, M, N, C = referenceVideoData.shape
 
-    assert C == 1, "strred called with videos containing %d channels. Please supply only the luminance channel" % (C,)
+    if not (C == 1):
+        raise ValueError("strred called with videos containing %d channels. Please supply only the luminance channel" % (C,))
 
     referenceVideoData = referenceVideoData[:, :, :, 0]
     distortedVideoData = distortedVideoData[:, :, :, 0]

--- a/skvideo/measure/videobliinds.py
+++ b/skvideo/measure/videobliinds.py
@@ -113,8 +113,10 @@ def computequality(img, blocksizerow, blocksizecol, mu_prisparam, cov_prisparam)
     h, w = img.shape
 
     if (h < blocksizerow) or (w < blocksizecol):
-        print("Input frame is too small")
-        exit(0)
+        raise ValueError(
+            "Input frame (%dx%d) is smaller than the block size %dx%d."
+            % (h, w, blocksizerow, blocksizecol)
+        )
 
     # ensure that the patch divides evenly into img
     hoffset = (h % blocksizerow)

--- a/skvideo/measure/videobliinds.py
+++ b/skvideo/measure/videobliinds.py
@@ -158,7 +158,8 @@ def compute_niqe_features(frames):
     blocksizecol = 96
 
     T, M, N, C = frames.shape
-    assert ((M >= blocksizerow*2) & (N >= blocksizecol*2)), "Video too small for NIQE extraction"
+    if not (((M >= blocksizerow*2) & (N >= blocksizecol*2))):
+        raise ValueError("Video too small for NIQE extraction")
 
     module_path = dirname(__file__)
     params = scipy.io.loadmat(join(module_path, 'data', 'frames_modelparameters.mat'))
@@ -316,7 +317,8 @@ def videobliinds_features(videoData):
 
     T, M, N, C = videoData.shape
 
-    assert C == 1, "videobliinds called with video having %d channels. Please supply only the luminance channel." % (C,)
+    if not (C == 1):
+        raise ValueError("videobliinds called with video having %d channels. Please supply only the luminance channel." % (C,))
 
     dt_dc_measure1 = temporal_dc_variation_feature_extraction(videoData)
     spectral_features = NSS_spectral_ratios_feature_extraction(videoData)

--- a/skvideo/measure/viideo.py
+++ b/skvideo/measure/viideo.py
@@ -131,7 +131,8 @@ def viideo_features(videoData, blocksize=(18, 18), blockoverlap=(8, 8), filterle
 
     T, M, N, C = videoData.shape
 
-    assert C == 1, "viideo called with video having %d channels. Please supply only the luminance channel." % (C,)
+    if not (C == 1):
+        raise ValueError("viideo called with video having %d channels. Please supply only the luminance channel." % (C,))
 
     hf = gauss_window_full(filterlength, filterlength/6.0)
     blockstrideY = blocksize[0]# - blockoverlap[0]

--- a/skvideo/motion/block.py
+++ b/skvideo/motion/block.py
@@ -992,6 +992,17 @@ def blockMotion(videodata, method='DS', mbSize=8, p=2, **plugin_args):
 def _subcomp(framedata, motionVect, mbSize):
     M, N, C = framedata.shape
 
+    # Validate the motion-vector grid against the macroblock grid. Without
+    # this, a too-small grid crashed with a cryptic IndexError and a
+    # too-large grid silently ignored the extra vectors.
+    motionVect = np.asarray(motionVect)
+    expectedGrid = (M // mbSize, N // mbSize)
+    if motionVect.shape[:2] != expectedGrid:
+        raise ValueError(
+            "motion-vector grid %s does not match the %s macroblock grid for "
+            "a %dx%d frame with mbSize=%d."
+            % (tuple(motionVect.shape[:2]), expectedGrid, M, N, mbSize))
+
     # Start from a copy of the frame so any border region not covered by a
     # whole macroblock (when M or N isn't a multiple of mbSize, e.g. 1080 /
     # 16) passes through unchanged instead of being silently zeroed. For
@@ -1035,7 +1046,18 @@ def blockComp(videodata, motionVect, mbSize=8):
     Returns
     -------
     compImg : ndarray
-        ndarray holding the motion compensated image frame, shape (T, M, N, C)
+        ndarray holding the motion compensated frames, shape (T, M, N, C)
+        and dtype ``float64``. A single input frame returns shape
+        (1, M, N, C).
+
+    Notes
+    -----
+    ``motionVect``'s grid must match the macroblock grid
+    (``M // mbSize`` by ``N // mbSize``); a mismatch raises ``ValueError``.
+    When ``M`` or ``N`` is not a multiple of ``mbSize``, the uncovered
+    bottom/right border is copied through from the input frame unchanged
+    (it cannot be motion-compensated). A motion vector that points outside
+    the frame leaves that block as the original (uncompensated) pixels.
 
     """
 
@@ -1045,8 +1067,9 @@ def blockComp(videodata, motionVect, mbSize=8):
     if T == 1:	# a single frame is passed in
         # vshape gives (1, M, N, C); _subcomp expects a single (M, N, C)
         # frame. Passing the 4D array crashed with "too many values to
-        # unpack".
-        return _subcomp(videodata[0], motionVect, mbSize)
+        # unpack". Return (1, M, N, C) to match the multi-frame path and
+        # the documented (T, M, N, C) shape.
+        return _subcomp(videodata[0], motionVect, mbSize)[np.newaxis, :, :, :]
 
     else: # more frames passed in
         # allocate compensation data

--- a/skvideo/motion/block.py
+++ b/skvideo/motion/block.py
@@ -992,16 +992,17 @@ def blockMotion(videodata, method='DS', mbSize=8, p=2, **plugin_args):
 def _subcomp(framedata, motionVect, mbSize):
     M, N, C = framedata.shape
 
-    # Validate the motion-vector grid against the macroblock grid. Without
-    # this, a too-small grid crashed with a cryptic IndexError and a
-    # too-large grid silently ignored the extra vectors.
+    # Validate the full motion-vector shape against the macroblock grid:
+    # (M//mbSize, N//mbSize, 2). Without this, a too-small grid crashed with
+    # a cryptic IndexError, a wrong last dimension (e.g. missing the dy/dx
+    # pair) also IndexError'd, and a too-large grid silently ignored extras.
     motionVect = np.asarray(motionVect)
-    expectedGrid = (M // mbSize, N // mbSize)
-    if motionVect.shape[:2] != expectedGrid:
+    expectedShape = (M // mbSize, N // mbSize, 2)
+    if motionVect.shape != expectedShape:
         raise ValueError(
-            "motion-vector grid %s does not match the %s macroblock grid for "
-            "a %dx%d frame with mbSize=%d."
-            % (tuple(motionVect.shape[:2]), expectedGrid, M, N, mbSize))
+            "motion vectors have shape %s but %s (M//mbSize, N//mbSize, 2) is "
+            "required for a %dx%d frame with mbSize=%d."
+            % (tuple(motionVect.shape), expectedShape, M, N, mbSize))
 
     # Start from a copy of the frame so any border region not covered by a
     # whole macroblock (when M or N isn't a multiple of mbSize, e.g. 1080 /

--- a/skvideo/motion/block.py
+++ b/skvideo/motion/block.py
@@ -947,7 +947,8 @@ def blockMotion(videodata, method='DS', mbSize=8, p=2, **plugin_args):
     luminancedata = rgb2gray(videodata)
 
     numFrames, height, width, channels = luminancedata.shape
-    assert numFrames > 1, "Must have more than 1 frame for motion estimation!"
+    if numFrames <= 1:
+        raise ValueError("Must have more than 1 frame for motion estimation!")
 
     # luminance is 1 channel, so flatten for computation
     luminancedata = luminancedata.reshape((numFrames, height, width))
@@ -991,7 +992,12 @@ def blockMotion(videodata, method='DS', mbSize=8, p=2, **plugin_args):
 def _subcomp(framedata, motionVect, mbSize):
     M, N, C = framedata.shape
 
-    compImg = np.zeros((M, N, C))
+    # Start from a copy of the frame so any border region not covered by a
+    # whole macroblock (when M or N isn't a multiple of mbSize, e.g. 1080 /
+    # 16) passes through unchanged instead of being silently zeroed. For
+    # frames whose dimensions divide evenly by mbSize, every cell is
+    # overwritten below, so this is identical to the old zero-init.
+    compImg = framedata.astype(np.float64)
 
     for i in range(0, M - mbSize + 1, mbSize):
         for j in range(0, N - mbSize + 1, mbSize):
@@ -1037,7 +1043,10 @@ def blockComp(videodata, motionVect, mbSize=8):
     T, M, N, C = videodata.shape
 
     if T == 1:	# a single frame is passed in
-        return _subcomp(videodata, motionVect, mbSize)
+        # vshape gives (1, M, N, C); _subcomp expects a single (M, N, C)
+        # frame. Passing the 4D array crashed with "too many values to
+        # unpack".
+        return _subcomp(videodata[0], motionVect, mbSize)
 
     else: # more frames passed in
         # allocate compensation data

--- a/skvideo/motion/block.py
+++ b/skvideo/motion/block.py
@@ -29,10 +29,15 @@ def _minCost(costs):
     return dx, dy, mi
 
 def _checkBounded(xval, yval, w, h, mbSize):
+    # A block at (xval, yval) occupies [xval, xval+mbSize) x [yval, yval+mbSize),
+    # so it fits when xval+mbSize <= w and yval+mbSize <= h. The previous test
+    # used >=, which wrongly rejected the block ending exactly at the frame
+    # edge — dropping every bottom/right macroblock (e.g. with a 16x16 frame
+    # and 8x8 blocks only the top-left block survived motion compensation).
     if ((yval < 0) or
-       (yval + mbSize >= h) or
+       (yval + mbSize > h) or
        (xval < 0) or
-       (xval + mbSize >= w)):
+       (xval + mbSize > w)):
         return False
     else:
         return True

--- a/skvideo/motion/gme.py
+++ b/skvideo/motion/gme.py
@@ -16,11 +16,11 @@ def _hausdorff_distance(E_1, E_2):
     diamond = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]])
 
     # extract only 1-pixel border line of objects
-    E_1_per = E_1^scipy.ndimage.morphology.binary_erosion(E_1, structure=diamond)
-    E_2_per = E_2^scipy.ndimage.morphology.binary_erosion(E_2, structure=diamond)
+    E_1_per = E_1^scipy.ndimage.binary_erosion(E_1, structure=diamond)
+    E_2_per = E_2^scipy.ndimage.binary_erosion(E_2, structure=diamond)
 
-    A = scipy.ndimage.morphology.distance_transform_edt(~E_2_per)[E_1_per].max()
-    B = scipy.ndimage.morphology.distance_transform_edt(~E_1_per)[E_2_per].max()
+    A = scipy.ndimage.distance_transform_edt(~E_2_per)[E_1_per].max()
+    B = scipy.ndimage.distance_transform_edt(~E_1_per)[E_2_per].max()
     return np.max((A, B))
 
 
@@ -73,16 +73,17 @@ def globalEdgeMotion(frame1, frame2, r=6, method='hamming'):
     else:
         assert C == 1, "called with frames having %d channels. Please supply only the luminance channel or RGB images." % (C,)
 
-    # if type bool, then these are edge maps. No need to convert them
+    # if type bool, then these are edge maps. No need to convert them, but
+    # still squeeze to 2D so the roll/morphology ops below see (M, N) like
+    # the canny() path produces (vshape made them 4D).
     if frame1.dtype != bool:
         E_1 = canny(frame1.squeeze())
     else:
-        E_1 = frame1
+        E_1 = frame1.squeeze()
     if frame2.dtype != bool:
-
         E_2 = canny(frame2.squeeze())
     else:
-        E_2 = frame2
+        E_2 = frame2.squeeze()
 
     distances = []
     displacements = []
@@ -94,9 +95,13 @@ def globalEdgeMotion(frame1, frame2, r=6, method='hamming'):
             if method == 'hamming':
                 distance = scipy.spatial.distance.hamming(np.ravel(cimage), np.ravel(E_1))
             elif method == 'hausdorff':
-                distance = _hausdorff_distance(cimage, E_2)
+                # cimage is the shifted frame2 edge map; measure its distance
+                # to frame1's edges (E_1), matching the hamming branch.
+                distance = _hausdorff_distance(cimage, E_1)
             else:
-                raise Notimplemented
+                raise NotImplementedError(
+                    "Unknown method %r; expected 'hamming' or 'hausdorff'." % (method,)
+                )
             # compute # of bit flip distance
             distances.append(distance)
             displacements.append([dx, dy])

--- a/skvideo/motion/gme.py
+++ b/skvideo/motion/gme.py
@@ -63,15 +63,16 @@ def globalEdgeMotion(frame1, frame2, r=6, method='hamming'):
     frame1 = vshape(frame1)
     frame2 = vshape(frame2)
     
-    assert(frame1.shape == frame2.shape)
+    if frame1.shape != frame2.shape:
+        raise ValueError("frame1 and frame2 must have the same shape; got %s vs %s" % (frame1.shape, frame2.shape))
 
     T, M, N, C = frame1.shape
 
     if C == 3:
         frame1 = rgb2gray(frame1)
         frame2 = rgb2gray(frame2)
-    else:
-        assert C == 1, "called with frames having %d channels. Please supply only the luminance channel or RGB images." % (C,)
+    elif C != 1:
+        raise ValueError("called with frames having %d channels. Please supply only the luminance channel or RGB images." % (C,))
 
     # if type bool, then these are edge maps. No need to convert them, but
     # still squeeze to 2D so the roll/morphology ops below see (M, N) like
@@ -84,6 +85,13 @@ def globalEdgeMotion(frame1, frame2, r=6, method='hamming'):
         E_2 = canny(frame2.squeeze())
     else:
         E_2 = frame2.squeeze()
+
+    # If either frame has no edges, there is no edge correspondence to
+    # minimize: every displacement ties (hamming would argmin to the first,
+    # i.e. (-r, -r)) and the hausdorff distance does an empty-array reduction
+    # and crashes. Report no detectable motion.
+    if not E_1.any() or not E_2.any():
+        return [0, 0]
 
     distances = []
     displacements = []

--- a/skvideo/motion/gme.py
+++ b/skvideo/motion/gme.py
@@ -49,8 +49,12 @@ def globalEdgeMotion(frame1, frame2, r=6, method='hamming'):
 
     Returns
     ----------
-    globalMotionVector  : ndarray, shape (2,)
-        The motion to minimize edge distances by moving frame2 with respect to frame1.
+    globalMotionVector  : list of int, length 2
+        The motion to minimize edge distances by moving frame2 with respect
+        to frame1. Returns ``[0, 0]`` when either frame contains no edges
+        (no edge correspondence to minimize), so a blank/edgeless frame
+        yields "no detected motion" rather than a spurious or crashing
+        result.
 
     References
     ----------

--- a/skvideo/tests/test_IOfail.py
+++ b/skvideo/tests/test_IOfail.py
@@ -10,18 +10,21 @@ def test_failedread():
 
 
 def test_failedwrite():
-    # 'garbage' folder does not exist
+    # 'garbage' folder does not exist -> not a writable directory.
+    # Validation now raises OSError instead of a bare assert (which would
+    # vanish under `python -O`).
     np.random.seed(0)
     outputdata = np.random.random(size=(5, 480, 640, 3)) * 255
     outputdata = outputdata.astype(np.uint8)
-    with pytest.raises(AssertionError):
+    with pytest.raises(OSError):
         skvideo.io.vwrite("garbage/garbage.mp4", outputdata)
 
 
 def test_failedextension():
-    # 'garbage' extension does not exist
+    # 'garbage' extension is not a known encoder extension -> ValueError
+    # (previously a bare assert, stripped under `python -O`).
     np.random.seed(0)
     outputdata = np.random.random(size=(5, 480, 640, 3)) * 255
     outputdata = outputdata.astype(np.uint8)
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         skvideo.io.vwrite("garbage.garbage", outputdata)

--- a/skvideo/tests/test_error_handling.py
+++ b/skvideo/tests/test_error_handling.py
@@ -143,3 +143,47 @@ def test_vwrite_rejects_zero_frames(tmp_path):
     import skvideo.io
     with pytest.raises(ValueError):
         skvideo.io.vwrite(str(tmp_path / "empty.mp4"), np.empty((0, 16, 16, 3)))
+
+
+def test_blockcomp_rejects_malformed_vector_rank():
+    """blockComp must reject motion vectors whose last dimension isn't 2
+    (or that are rank-2) with a clear ValueError, not a cryptic IndexError
+    / silent ignore of extra components."""
+    import skvideo.motion as MO
+    frame = np.ones((16, 16, 1))  # single frame -> _subcomp gets motionVect directly
+    for bad in [(2, 2), (2, 2, 1), (2, 2, 3)]:
+        with pytest.raises(ValueError):
+            MO.blockComp(frame, np.zeros(bad, dtype=np.int64), mbSize=8)
+    # the correct shape still works
+    ok = MO.blockComp(frame, np.zeros((2, 2, 2), dtype=np.int64), mbSize=8)
+    assert ok.shape == (1, 16, 16, 1)
+
+
+def test_bytesio_writer_close_emits_no_resourcewarning():
+    """Closing a BytesIO writer must not leak ffmpeg pipe file objects
+    (previously emitted ResourceWarning: unclosed file per writer)."""
+    import io as _io
+    import warnings
+    import skvideo.io
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ResourceWarning)
+        buf = _io.BytesIO()
+        w = skvideo.io.FFmpegWriter(buf, inputdict={"-r": "5"}, outputdict={"-f": "mp4"})
+        for _ in range(3):
+            w.writeFrame(np.zeros((16, 16, 3), dtype=np.uint8))
+        w.close()  # must not raise ResourceWarning
+
+
+def test_setffmpegpath_bad_path_clears_codec_caches():
+    """A bad setFFmpegPath must not leave stale decoder/encoder lists from a
+    previously valid binary (half-configured state)."""
+    import skvideo
+    orig = skvideo._FFMPEG_PATH
+    try:
+        skvideo.setFFmpegPath("/nonexistent/skvideo/path")
+        assert skvideo._HAS_FFMPEG == 0
+        assert skvideo._FFMPEG_SUPPORTED_DECODERS == []
+        assert skvideo._FFMPEG_SUPPORTED_ENCODERS == []
+    finally:
+        skvideo.setFFmpegPath(orig)  # restore for the rest of the session
+    assert skvideo._HAS_FFMPEG == 1

--- a/skvideo/tests/test_error_handling.py
+++ b/skvideo/tests/test_error_handling.py
@@ -71,3 +71,61 @@ def test_ffprobe_warns_on_unparseable_file(tmp_path):
     with pytest.warns(UserWarning):
         info = skvideo.io.ffprobe(str(bogus))
     assert info == {}
+
+
+def test_fullref_metric_rejects_shape_mismatch():
+    """Full-reference metrics must reject mismatched ref/dis shapes with a
+    real exception (was a bare `assert`, stripped under -O where mismatched
+    arrays broadcast to a plausible-but-wrong score)."""
+    import skvideo.measure as M
+    a = np.zeros((2, 16, 16, 1))
+    b = np.zeros((3, 16, 16, 1))
+    for fn in (M.mse, M.mae, M.psnr):
+        with pytest.raises(ValueError):
+            fn(a, b)
+
+
+def test_fullref_shape_mismatch_survives_O():
+    import subprocess, sys
+    code = (
+        "import numpy as np, skvideo.measure as m\n"
+        "try:\n"
+        "    m.mse(np.zeros((2,16,16,1)), np.zeros((3,16,16,1)))\n"
+        "    print('NORAISE')\n"
+        "except ValueError:\n"
+        "    print('VALUEERROR')\n"
+    )
+    out = subprocess.run([sys.executable, "-O", "-c", code], capture_output=True, text=True)
+    assert "VALUEERROR" in out.stdout, (out.stdout, out.stderr[-200:])
+
+
+def test_blockcomp_nondivisible_dims_pass_through_remainder():
+    """A frame whose dimensions aren't a multiple of mbSize (e.g. 1080/16)
+    must not have its uncovered border silently zeroed; the remainder passes
+    through instead."""
+    import skvideo.motion as MO
+    frame = np.ones((17, 17, 1)) * 7.0
+    vid = np.stack([frame, frame])
+    mv = np.zeros((1, 17 // 8, 17 // 8, 2), dtype=np.int64)
+    comp = MO.blockComp(vid, mv, mbSize=8)
+    # bottom row (index 16) is outside any whole 8x8 block -> must be 7, not 0
+    assert comp[1, 16, :, 0].min() == 7.0
+
+
+def test_blockcomp_single_frame_does_not_crash():
+    import skvideo.motion as MO
+    out = MO.blockComp(np.ones((16, 16, 1)), np.zeros((2, 2, 2), dtype=np.int64), mbSize=8)
+    assert out.shape == (16, 16, 1)
+
+
+def test_globalEdgeMotion_blank_frames_report_no_motion():
+    import skvideo.motion as MO
+    z = np.zeros((40, 40), np.float32)
+    assert list(MO.globalEdgeMotion(z, z, method="hamming")) == [0, 0]
+    assert list(MO.globalEdgeMotion(z, z, method="hausdorff")) == [0, 0]
+
+
+def test_vwrite_rejects_zero_frames(tmp_path):
+    import skvideo.io
+    with pytest.raises(ValueError):
+        skvideo.io.vwrite(str(tmp_path / "empty.mp4"), np.empty((0, 16, 16, 3)))

--- a/skvideo/tests/test_error_handling.py
+++ b/skvideo/tests/test_error_handling.py
@@ -33,3 +33,29 @@ def test_videobliinds_computequality_raises_on_small_frame_instead_of_exit():
     tiny = np.zeros((4, 4, 1), dtype=np.float32)
     with pytest.raises(ValueError):
         _vbliinds_mod.computequality(tiny, 96, 96, None, None)
+
+
+def test_input_validation_survives_O_optimization():
+    """Public input validation must use real exceptions, not `assert`, so it
+    is not stripped under `python -O`. Previously `mse` asserted on the
+    channel count; under -O that vanished and mse returned [0.] for RGB."""
+    import subprocess
+    import sys
+
+    code = (
+        "import numpy as np, skvideo.measure as m\n"
+        "rgb = np.zeros((2, 16, 16, 3))\n"
+        "try:\n"
+        "    m.mse(rgb, rgb)\n"
+        "    print('NORAISE')\n"
+        "except ValueError:\n"
+        "    print('VALUEERROR')\n"
+    )
+    out = subprocess.run(
+        [sys.executable, "-O", "-c", code],
+        capture_output=True, text=True,
+    )
+    assert "VALUEERROR" in out.stdout, (
+        "mse did not raise under -O; stdout=%r stderr=%r"
+        % (out.stdout, out.stderr[-200:])
+    )

--- a/skvideo/tests/test_error_handling.py
+++ b/skvideo/tests/test_error_handling.py
@@ -115,7 +115,21 @@ def test_blockcomp_nondivisible_dims_pass_through_remainder():
 def test_blockcomp_single_frame_does_not_crash():
     import skvideo.motion as MO
     out = MO.blockComp(np.ones((16, 16, 1)), np.zeros((2, 2, 2), dtype=np.int64), mbSize=8)
-    assert out.shape == (16, 16, 1)
+    # single-frame result is (1, M, N, C), consistent with the multi-frame path
+    assert out.shape == (1, 16, 16, 1)
+
+
+def test_blockcomp_rejects_mismatched_motion_grid():
+    """A motion-vector grid that doesn't match the macroblock grid must raise
+    a clear ValueError, not a cryptic IndexError (too small) or silently
+    ignore extra vectors (too large)."""
+    import skvideo.motion as MO
+    frame = np.ones((16, 16, 1))  # 2x2 macroblock grid at mbSize=8
+    vid = np.stack([frame, frame])
+    with pytest.raises(ValueError):
+        MO.blockComp(vid, np.zeros((1, 1, 1, 2), dtype=np.int64), mbSize=8)
+    with pytest.raises(ValueError):
+        MO.blockComp(vid, np.zeros((1, 3, 3, 2), dtype=np.int64), mbSize=8)
 
 
 def test_globalEdgeMotion_blank_frames_report_no_motion():

--- a/skvideo/tests/test_error_handling.py
+++ b/skvideo/tests/test_error_handling.py
@@ -59,3 +59,15 @@ def test_input_validation_survives_O_optimization():
         "mse did not raise under -O; stdout=%r stderr=%r"
         % (out.stdout, out.stderr[-200:])
     )
+
+
+def test_ffprobe_warns_on_unparseable_file(tmp_path):
+    """ffprobe returning {} is load-bearing for raw video, but it must no
+    longer do so silently: an unparseable file should emit a UserWarning
+    explaining why, rather than vanishing behind a later generic error."""
+    import skvideo.io
+    bogus = tmp_path / "not_a_video.mp4"
+    bogus.write_bytes(b"this is plainly not a media file")
+    with pytest.warns(UserWarning):
+        info = skvideo.io.ffprobe(str(bogus))
+    assert info == {}

--- a/skvideo/tests/test_error_handling.py
+++ b/skvideo/tests/test_error_handling.py
@@ -1,0 +1,35 @@
+"""Library code must raise exceptions, not return non-exception singletons
+or call exit() (which would kill the host process)."""
+import importlib
+
+import numpy as np
+import pytest
+
+import skvideo.utils
+
+# The function `niqe` shadows the `niqe` submodule in skvideo.measure's
+# namespace, so import the modules explicitly to reach their helpers.
+_niqe_mod = importlib.import_module("skvideo.measure.niqe")
+_vbliinds_mod = importlib.import_module("skvideo.measure.videobliinds")
+
+
+def test_rgb2gray_rejects_alpha_with_real_exception():
+    # Previously `raise NotImplemented` (the singleton), which itself
+    # raises "TypeError: exceptions must derive from BaseException".
+    rgba = np.zeros((1, 16, 16, 4), dtype=np.uint8)
+    with pytest.raises(NotImplementedError):
+        skvideo.utils.rgb2gray(rgba)
+
+
+def test_niqe_patches_raises_on_small_image_instead_of_exit():
+    # _get_patches_generic used exit(0) on an undersized image, terminating
+    # the caller's process. It must raise instead.
+    tiny = np.zeros((4, 4), dtype=np.float32)
+    with pytest.raises(ValueError):
+        _niqe_mod._get_patches_generic(tiny, 96, 0, 1)
+
+
+def test_videobliinds_computequality_raises_on_small_frame_instead_of_exit():
+    tiny = np.zeros((4, 4, 1), dtype=np.float32)
+    with pytest.raises(ValueError):
+        _vbliinds_mod.computequality(tiny, 96, 96, None, None)

--- a/skvideo/tests/test_frame_range.py
+++ b/skvideo/tests/test_frame_range.py
@@ -88,3 +88,27 @@ def test_vreader_supports_start_frame():
     frames = list(reader)
     assert len(frames) == 10
     assert frames[0].shape == (720, 1280, 3)
+
+
+def test_vread_trims_to_actual_frames_with_output_filter():
+    """When an output filter (-vf select) yields fewer frames than
+    getShape() predicts from nb_frames, vread must return only the frames
+    actually produced, not an over-allocated array padded with
+    uninitialized np.empty rows.
+    """
+    full = skvideo.io.vread(skvideo.datasets.bigbuckbunny())
+    total = full.shape[0]
+    # Keep only the last two frames via an output-side select filter.
+    # -vsync 0 is required so FFmpeg doesn't re-pad the dropped frames back
+    # to a constant rate (which would undo the selection).
+    keep_from = total - 2
+    selected = skvideo.io.vread(
+        skvideo.datasets.bigbuckbunny(),
+        outputdict={"-vf": "select='gte(n\\,%d)'" % keep_from, "-vsync": "0"},
+    )
+    assert selected.shape[0] == 2, (
+        "expected 2 selected frames, got %d (over-allocation not trimmed)"
+        % selected.shape[0]
+    )
+    # The trimmed frames must be the real tail frames, not uninitialized data.
+    assert np.array_equal(selected, full[keep_from:total])

--- a/skvideo/tests/test_import_star.py
+++ b/skvideo/tests/test_import_star.py
@@ -1,0 +1,19 @@
+"""Guard against a malformed top-level ``__all__``.
+
+``skvideo.__all__`` previously listed the function *objects* rather than
+their names, so ``from skvideo import *`` raised
+``TypeError: Item in skvideo.__all__ must be str, not function``.
+"""
+import skvideo
+
+
+def test_all_entries_are_strings():
+    assert all(isinstance(name, str) for name in skvideo.__all__)
+
+
+def test_import_star_does_not_raise():
+    namespace = {}
+    exec("from skvideo import *", namespace)
+    # Every advertised name should resolve to a real attribute.
+    for name in skvideo.__all__:
+        assert name in namespace, "%s not exported by import *" % name

--- a/skvideo/tests/test_measure.py
+++ b/skvideo/tests/test_measure.py
@@ -119,6 +119,23 @@ def test_measure_VideoBliinds():
     for i in range(features.shape[0]):
       assert_almost_equal(features[i], output[i], decimal=2)
 
+def test_measure_Li3DDCT_smoke():
+    # Smoke test only: the exported Li3DDCT_features previously raised
+    # NameError ('int32' not defined) on every Python-3 call, so there is
+    # no historical reference output to pin. Verify it runs and returns a
+    # finite (5*63,) feature vector. Also exercises the T==4 minimum.
+    vidpath = skvideo.datasets.bigbuckbunny()
+    dis = skvideo.io.vread(vidpath, as_grey=True)[:8, :64, :64]
+    features = skvideo.measure.Li3DDCT_features(dis)
+    assert features.shape == (5 * 63,)
+    assert np.all(np.isfinite(features))
+
+    # T == 4 is the documented minimum and must yield one group of frames,
+    # not an empty slice.
+    features4 = skvideo.measure.Li3DDCT_features(dis[:4])
+    assert features4.shape == (5 * 63,)
+    assert np.all(np.isfinite(features4))
+
 def test_measure_SSIM():
     vidpaths = skvideo.datasets.fullreferencepair()
     ref = skvideo.io.vread(vidpaths[0], as_grey=True)

--- a/skvideo/tests/test_memory_input.py
+++ b/skvideo/tests/test_memory_input.py
@@ -1,5 +1,6 @@
 """Tests for BytesIO / file-like input support (issue #113)."""
 import io
+import os
 from pathlib import Path
 
 import numpy as np
@@ -89,3 +90,37 @@ def test_file_path_does_not_create_temp_file(tmp_path, bunny_bytes):
         assert reader._temp_input_path is None
     finally:
         reader.close()
+
+
+def test_no_temp_leak_when_constructor_fails():
+    """If the constructor raises after spooling (e.g. probe can't parse the
+    bytes), the spooled temp file must still be cleaned up — the caller
+    never gets a reference, so they can't call close() themselves.
+
+    Codex round 1 review flagged this lifecycle gap.
+    """
+    import glob
+    import tempfile as _tempfile
+
+    # Use the system tempdir directly: macOS uses /var/folders/... not /tmp.
+    tempdir = _tempfile.gettempdir()
+    pattern = os.path.join(tempdir, "skvideo_in_*")
+
+    junk = io.BytesIO(b"this is not a video file")
+    before = set(glob.glob(pattern))
+    with pytest.raises(Exception):
+        skvideo.io.FFmpegReader(junk)
+    after = set(glob.glob(pattern))
+    leaked = after - before
+    # Clean up any leak the test exposed so we don't litter the temp dir
+    # across CI runs.
+    for path in leaked:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+    assert not leaked, (
+        "Constructor failure left %d temp file(s) behind: %s" % (
+            len(leaked), sorted(leaked)
+        )
+    )

--- a/skvideo/tests/test_memory_input.py
+++ b/skvideo/tests/test_memory_input.py
@@ -96,8 +96,6 @@ def test_no_temp_leak_when_constructor_fails():
     """If the constructor raises after spooling (e.g. probe can't parse the
     bytes), the spooled temp file must still be cleaned up — the caller
     never gets a reference, so they can't call close() themselves.
-
-    Codex round 1 review flagged this lifecycle gap.
     """
     import glob
     import tempfile as _tempfile
@@ -124,3 +122,66 @@ def test_no_temp_leak_when_constructor_fails():
             len(leaked), sorted(leaked)
         )
     )
+
+
+def test_write_only_input_rejected():
+    """A file-like object without read() can't be an input source. Reject it
+    with a clear TypeError up front rather than failing deep inside the
+    spool copy with an opaque AttributeError (and leaking a temp file)."""
+    class _WriteOnly:
+        def write(self, b):
+            return len(b)
+    with pytest.raises(TypeError, match="read"):
+        skvideo.io.FFmpegReader(_WriteOnly())
+
+
+def test_no_temp_leak_when_source_read_fails():
+    """If source.read() raises partway through spooling, the temp file must
+    be unlinked before the exception propagates."""
+    import glob
+    import tempfile as _tempfile
+
+    pattern = os.path.join(_tempfile.gettempdir(), "skvideo_in_*")
+
+    class _Boom:
+        def read(self, n=-1):
+            raise IOError("simulated read failure")
+
+    before = set(glob.glob(pattern))
+    with pytest.raises(Exception):
+        skvideo.io.FFmpegReader(_Boom())
+    after = set(glob.glob(pattern))
+    leaked = after - before
+    for path in leaked:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+    assert not leaked, "Spool read failure leaked: %s" % sorted(leaked)
+
+
+def test_vread_cleans_spool_on_read_error(bunny_bytes, monkeypatch):
+    """vread() must close the reader even if frame reading raises mid-loop,
+    so a spooled BytesIO temp file is unlinked (the read path is wrapped in
+    try/finally)."""
+    import glob
+    import tempfile as _tempfile
+
+    pattern = os.path.join(_tempfile.gettempdir(), "skvideo_in_*")
+
+    def boom(self):
+        raise RuntimeError("simulated mid-read failure")
+        yield  # pragma: no cover  (makes this a generator)
+
+    monkeypatch.setattr(skvideo.io.FFmpegReader, "nextFrame", boom)
+    before = set(glob.glob(pattern))
+    with pytest.raises(RuntimeError):
+        skvideo.io.vread(io.BytesIO(bunny_bytes))
+    after = set(glob.glob(pattern))
+    leaked = after - before
+    for path in leaked:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+    assert not leaked, "vread read failure leaked spool: %s" % sorted(leaked)

--- a/skvideo/tests/test_memory_input.py
+++ b/skvideo/tests/test_memory_input.py
@@ -1,0 +1,91 @@
+"""Tests for BytesIO / file-like input support (issue #113)."""
+import io
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import skvideo.io
+import skvideo.datasets
+
+
+@pytest.fixture(scope="module")
+def bunny_bytes():
+    """The bigbuckbunny mp4 loaded fully into memory as bytes."""
+    with open(skvideo.datasets.bigbuckbunny(), "rb") as fh:
+        return fh.read()
+
+
+def test_vread_from_bytesio(bunny_bytes):
+    """vread() should accept a BytesIO of mp4 bytes and decode it."""
+    buf = io.BytesIO(bunny_bytes)
+    videodata = skvideo.io.vread(buf, num_frames=3)
+    assert videodata.shape == (3, 720, 1280, 3)
+
+
+def test_ffmpegreader_from_bytesio(bunny_bytes):
+    """FFmpegReader directly should also accept BytesIO; previously
+    crashed at os.path.getsize() / os.fspath() on the BytesIO object."""
+    buf = io.BytesIO(bunny_bytes)
+    reader = skvideo.io.FFmpegReader(buf)
+    try:
+        shape = reader.getShape()
+        # Frame count comes from probe; height/width/channels are deterministic.
+        assert shape[1:] == (720, 1280, 3)
+    finally:
+        reader.close()
+
+
+def test_vreader_from_bytesio(bunny_bytes):
+    """The generator API mirrors vread()."""
+    buf = io.BytesIO(bunny_bytes)
+    frames = []
+    for frame in skvideo.io.vreader(buf, num_frames=2):
+        frames.append(frame)
+    assert len(frames) == 2
+    assert frames[0].shape == (720, 1280, 3)
+
+
+def test_bytesio_at_nonzero_position(bunny_bytes):
+    """If the caller hands us a BytesIO with the cursor already advanced,
+    we should still read from the start (we seek(0) internally)."""
+    buf = io.BytesIO(bunny_bytes)
+    buf.seek(1024)  # caller already consumed some bytes
+    videodata = skvideo.io.vread(buf, num_frames=2)
+    assert videodata.shape == (2, 720, 1280, 3)
+
+
+def test_open_file_handle(tmp_path, bunny_bytes):
+    """An open binary file handle works just like a BytesIO; its .name
+    attribute should let us preserve the extension on the temp spool."""
+    p = tmp_path / "video.mp4"
+    p.write_bytes(bunny_bytes)
+    with open(p, "rb") as fh:
+        videodata = skvideo.io.vread(fh, num_frames=2)
+    assert videodata.shape == (2, 720, 1280, 3)
+
+
+def test_temp_file_cleaned_up_on_close(bunny_bytes):
+    """The spooled temp file must be unlinked when the reader closes,
+    otherwise long-running processes leak files into /tmp."""
+    buf = io.BytesIO(bunny_bytes)
+    reader = skvideo.io.FFmpegReader(buf)
+    spooled_path = reader._temp_input_path
+    assert spooled_path is not None
+    assert Path(spooled_path).exists()
+    reader.close()
+    assert not Path(spooled_path).exists(), (
+        "Spooled temp file %s still exists after close()" % spooled_path
+    )
+
+
+def test_file_path_does_not_create_temp_file(tmp_path, bunny_bytes):
+    """Regression guard: a regular file path must NOT trigger spooling.
+    _temp_input_path stays None so close() has nothing to unlink."""
+    p = tmp_path / "video.mp4"
+    p.write_bytes(bunny_bytes)
+    reader = skvideo.io.FFmpegReader(str(p))
+    try:
+        assert reader._temp_input_path is None
+    finally:
+        reader.close()

--- a/skvideo/tests/test_memory_input.py
+++ b/skvideo/tests/test_memory_input.py
@@ -131,8 +131,19 @@ def test_write_only_input_rejected():
     class _WriteOnly:
         def write(self, b):
             return len(b)
-    with pytest.raises(TypeError, match="read"):
+    with pytest.raises(TypeError, match="readable"):
         skvideo.io.FFmpegReader(_WriteOnly())
+
+
+def test_write_mode_file_handle_rejected(tmp_path):
+    """A real file opened in write mode ("wb") exposes a .read attribute
+    that raises io.UnsupportedOperation when called, so a plain
+    hasattr("read") check would pass it and then fail deep in the spool
+    copy. The readable() probe must reject it up front with a TypeError."""
+    p = tmp_path / "out.mp4"
+    with open(p, "wb") as wb:
+        with pytest.raises(TypeError, match="readable"):
+            skvideo.io.FFmpegReader(wb)
 
 
 def test_no_temp_leak_when_source_read_fails():

--- a/skvideo/tests/test_memory_output.py
+++ b/skvideo/tests/test_memory_output.py
@@ -1,0 +1,102 @@
+"""Tests for BytesIO / file-like output support (issue #113 write-side)."""
+import io
+
+import numpy as np
+import pytest
+
+import skvideo.io
+
+
+def test_vwrite_to_bytesio_writes_bytes():
+    """The basic guarantee: vwrite(BytesIO, data) actually fills the buffer.
+    Previously crashed at os.path.abspath(BytesIO) before commit 5."""
+    buf = io.BytesIO()
+    data = np.zeros((10, 64, 64, 3), dtype=np.uint8)
+    skvideo.io.vwrite(buf, data)
+    assert buf.tell() > 0, "BytesIO is empty after vwrite — drain thread didn't run?"
+
+
+def test_bytesio_output_round_trips():
+    """Write frames to BytesIO, then read them back via the BytesIO reader.
+    End-to-end proof that the memory writer produces a valid container."""
+    out = io.BytesIO()
+    written = np.zeros((5, 64, 64, 3), dtype=np.uint8)
+    # Make each frame distinguishable so a silent corruption (all zeros)
+    # gets caught.
+    for i in range(5):
+        written[i] = (i + 1) * 30  # 30, 60, 90, 120, 150
+    skvideo.io.vwrite(out, written)
+    out.seek(0)
+
+    read_back = skvideo.io.vread(out)
+    assert read_back.shape == (5, 64, 64, 3)
+    # We won't get bit-exact pixels back (h264 is lossy at default settings),
+    # but mean per frame should preserve the gradient.
+    means = read_back.reshape(5, -1).mean(axis=1)
+    assert np.all(np.diff(means) > 10), (
+        "Frame mean gradient lost in round-trip: %r" % means.tolist()
+    )
+
+
+def test_ffmpegwriter_directly_to_bytesio():
+    """Lower-level FFmpegWriter path also accepts BytesIO."""
+    buf = io.BytesIO()
+    writer = skvideo.io.FFmpegWriter(buf)
+    try:
+        for _ in range(3):
+            writer.writeFrame(np.zeros((64, 64, 3), dtype=np.uint8))
+    finally:
+        writer.close()
+    assert buf.tell() > 0
+
+
+def test_bytesio_writer_propagates_user_format_choice():
+    """If the user picks a different container (e.g. webm), the wrapper
+    must not override their choice with its mp4 default."""
+    buf = io.BytesIO()
+    writer = skvideo.io.FFmpegWriter(
+        buf,
+        outputdict={"-f": "webm", "-vcodec": "libvpx-vp9", "-b:v": "200k"},
+    )
+    try:
+        for _ in range(3):
+            writer.writeFrame(np.zeros((64, 64, 3), dtype=np.uint8))
+    finally:
+        writer.close()
+    # webm files start with the EBML magic bytes 0x1A 0x45 0xDF 0xA3
+    body = buf.getvalue()
+    assert body[:4] == b"\x1a\x45\xdf\xa3", (
+        "Expected webm EBML magic; got %r — wrapper may have overridden -f" %
+        body[:8]
+    )
+
+
+def test_bytesio_writer_surfaces_ffmpeg_failure():
+    """If ffmpeg fails (e.g. bogus codec), close() should raise with a
+    useful error rather than silently producing an empty BytesIO."""
+    buf = io.BytesIO()
+    writer = skvideo.io.FFmpegWriter(
+        buf,
+        outputdict={"-vcodec": "this_codec_does_not_exist_xyz"},
+    )
+    with pytest.raises((RuntimeError, IOError)):
+        writer.writeFrame(np.zeros((64, 64, 3), dtype=np.uint8))
+        writer.close()
+
+
+def test_bytesio_writer_drain_thread_cleans_up():
+    """After close(), the drain thread must have finished — no zombie
+    threads holding refs to the user's buffer."""
+    buf = io.BytesIO()
+    writer = skvideo.io.FFmpegWriter(buf)
+    try:
+        for _ in range(3):
+            writer.writeFrame(np.zeros((64, 64, 3), dtype=np.uint8))
+    finally:
+        writer.close()
+    # Thread reference still on the writer (for introspection); just verify
+    # it's no longer alive.
+    assert writer._stdout_drain_thread is not None
+    assert not writer._stdout_drain_thread.is_alive(), (
+        "drain thread is still alive after close()"
+    )

--- a/skvideo/tests/test_memory_output.py
+++ b/skvideo/tests/test_memory_output.py
@@ -100,3 +100,29 @@ def test_bytesio_writer_drain_thread_cleans_up():
     assert not writer._stdout_drain_thread.is_alive(), (
         "drain thread is still alive after close()"
     )
+
+
+def test_bytesio_writer_surfaces_destination_write_failure():
+    """If the user's destination .write() raises (closed file, full disk,
+    custom sink hitting I/O error, ...), close() must re-raise the error
+    in the main thread instead of swallowing it silently.
+
+    The _stdout_drain_error channel is the contract here — the drain
+    thread can't raise across the thread boundary directly, so it stores
+    the exception for close() to surface (Codex round 1 finding: the
+    plumbing existed but wasn't tested).
+    """
+    class _BadSink:
+        """Looks like a writable buffer, but every write fails."""
+        def write(self, data):
+            raise IOError("simulated sink write failure")
+
+    writer = skvideo.io.FFmpegWriter(_BadSink())
+    with pytest.raises(RuntimeError, match="destination write failed"):
+        # The drain thread will fail on its first write; the failure
+        # surfaces when we tear down. Whether the failure shows up in
+        # writeFrame() (if ffmpeg blocks fast enough) or in close()
+        # depends on timing, so accept either.
+        for _ in range(20):
+            writer.writeFrame(np.zeros((64, 64, 3), dtype=np.uint8))
+        writer.close()

--- a/skvideo/tests/test_motion.py
+++ b/skvideo/tests/test_motion.py
@@ -123,3 +123,33 @@ def test_blockComp_zero_motion_covers_full_frame():
     assert_equal(comp[1], vid[1])
     # The previously-dropped bottom-right block must now be filled.
     assert comp[1, 8:16, 8:16, 0].min() > 0
+
+
+def test_globalEdgeMotion_recovers_known_shift():
+    # globalEdgeMotion was fully broken on Python 3: canny() hit a bare
+    # `int32` NameError (image input), and the hausdorff branch compared
+    # the shifted frame against itself and misspelled the raise. Verify
+    # both methods recover a known translation.
+    f1 = np.zeros((40, 40), np.float32)
+    f1[10:30, 10:30] = 255.0  # a square with detectable edges
+    f2 = np.roll(np.roll(f1, 3, axis=0), 2, axis=1)
+    # Motion that moves f2 back onto f1 is (-3, -2).
+    assert list(skvideo.motion.globalEdgeMotion(f1, f2, r=6, method="hamming")) == [-3, -2]
+    assert list(skvideo.motion.globalEdgeMotion(f1, f2, r=6, method="hausdorff")) == [-3, -2]
+
+
+def test_globalEdgeMotion_rejects_unknown_method():
+    f1 = np.zeros((20, 20), np.float32)
+    f1[5:15, 5:15] = 255.0
+    with __import__("pytest").raises(NotImplementedError):
+        skvideo.motion.globalEdgeMotion(f1, f1, method="bogus")
+
+
+def test_canny_runs_on_image():
+    # Regression: canny() used a bare `int32` (NameError on py3).
+    import skvideo.utils
+    img = np.zeros((32, 32), np.float32)
+    img[8:24, 8:24] = 255.0
+    edges = skvideo.utils.canny(img)
+    assert edges.shape == (32, 32)
+    assert edges.dtype == bool or edges.sum() >= 0  # ran without crashing

--- a/skvideo/tests/test_motion.py
+++ b/skvideo/tests/test_motion.py
@@ -104,3 +104,22 @@ def test_DS():
 
     assert_almost_equal(ymean, 0.013888888992369, decimal=15)
     assert_almost_equal(xmean, -0.347222208976746, decimal=15)
+
+
+def test_blockComp_zero_motion_covers_full_frame():
+    # Regression: _checkBounded used >= and rejected blocks ending exactly
+    # at the frame edge, so blockComp dropped every bottom/right macroblock.
+    # With zero motion vectors, compensation must reproduce the frame
+    # exactly, including the bottom-right block.
+    mbSize = 8
+    frame = np.arange(16 * 16, dtype=np.float64).reshape(16, 16, 1) + 1.0  # all nonzero
+    vid = np.stack([frame, frame], axis=0)
+    mv = np.zeros((1, 16 // mbSize, 16 // mbSize, 2), dtype=np.int64)
+
+    comp = skvideo.motion.blockComp(vid, mv, mbSize=mbSize)
+
+    # Frame 0 is passed through; frame 1 is compensated and, under zero
+    # motion, must equal the original frame everywhere.
+    assert_equal(comp[1], vid[1])
+    # The previously-dropped bottom-right block must now be filled.
+    assert comp[1, 8:16, 8:16, 0].min() > 0

--- a/skvideo/tests/test_protocol_detection.py
+++ b/skvideo/tests/test_protocol_detection.py
@@ -1,4 +1,10 @@
-"""Tests for ffmpeg protocol detection + warning (v1.1.14)."""
+"""Tests for ffmpeg protocol detection + warning (v1.1.14).
+
+After Codex round 1 the cache moved from two separate globals
+(_FFMPEG_INPUT_PROTOCOLS, _FFMPEG_OUTPUT_PROTOCOLS) to a single atomic
+tuple (_FFMPEG_PROTOCOLS = (inputs, outputs)) so concurrent readers
+can't observe one half populated and the other half None.
+"""
 import warnings
 
 import pytest
@@ -25,8 +31,7 @@ def test_parser_extracts_input_and_output_protocols(monkeypatch):
         b"  md5\n"
         b"  pipe\n"
     )
-    monkeypatch.setattr(skvideo, "_FFMPEG_INPUT_PROTOCOLS", None)
-    monkeypatch.setattr(skvideo, "_FFMPEG_OUTPUT_PROTOCOLS", None)
+    monkeypatch.setattr(skvideo, "_FFMPEG_PROTOCOLS", None)
     monkeypatch.setattr(skvideo, "check_output", lambda *a, **k: fake_output)
 
     inputs, outputs = skvideo._get_ffmpeg_protocols()
@@ -42,8 +47,7 @@ def test_parser_caches_result(monkeypatch):
         call_count["n"] += 1
         return b"Supported file protocols:\nInput:\n  file\nOutput:\n  file\n"
 
-    monkeypatch.setattr(skvideo, "_FFMPEG_INPUT_PROTOCOLS", None)
-    monkeypatch.setattr(skvideo, "_FFMPEG_OUTPUT_PROTOCOLS", None)
+    monkeypatch.setattr(skvideo, "_FFMPEG_PROTOCOLS", None)
     monkeypatch.setattr(skvideo, "check_output", fake_check_output)
 
     skvideo._get_ffmpeg_protocols()
@@ -57,8 +61,7 @@ def test_parser_handles_detection_failure(monkeypatch):
     def boom(*a, **k):
         raise OSError("ffmpeg crashed")
 
-    monkeypatch.setattr(skvideo, "_FFMPEG_INPUT_PROTOCOLS", None)
-    monkeypatch.setattr(skvideo, "_FFMPEG_OUTPUT_PROTOCOLS", None)
+    monkeypatch.setattr(skvideo, "_FFMPEG_PROTOCOLS", None)
     monkeypatch.setattr(skvideo, "check_output", boom)
 
     inputs, outputs = skvideo._get_ffmpeg_protocols()
@@ -66,12 +69,30 @@ def test_parser_handles_detection_failure(monkeypatch):
     assert outputs == []
 
 
+def test_cache_is_atomic_tuple(monkeypatch):
+    """Codex round 1: when the cache gets populated it must be a single
+    tuple assignment, not two separate writes. Otherwise a concurrent
+    reader can see inputs set and outputs still None.
+
+    We can't easily reproduce the race in a single-threaded test, but
+    we can verify the post-detection state has exactly one published
+    cache object (the tuple), not two separate attributes.
+    """
+    monkeypatch.setattr(skvideo, "_FFMPEG_PROTOCOLS", None)
+    monkeypatch.setattr(
+        skvideo, "check_output",
+        lambda *a, **k: b"Input:\n  file\nOutput:\n  file\n"
+    )
+    skvideo._get_ffmpeg_protocols()
+    assert isinstance(skvideo._FFMPEG_PROTOCOLS, tuple)
+    assert len(skvideo._FFMPEG_PROTOCOLS) == 2
+
+
 # --- warn behavior tests -----------------------------------------------------
 
 def test_warn_fires_for_unsupported_scheme(monkeypatch):
     """When the URL scheme isn't in the supported list, a UserWarning fires."""
-    monkeypatch.setattr(skvideo, "_FFMPEG_INPUT_PROTOCOLS", ["file", "http", "pipe"])
-    monkeypatch.setattr(skvideo, "_FFMPEG_OUTPUT_PROTOCOLS", ["file", "pipe"])
+    monkeypatch.setattr(skvideo, "_FFMPEG_PROTOCOLS", (["file", "http", "pipe"], ["file", "pipe"]))
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
@@ -85,8 +106,7 @@ def test_warn_fires_for_unsupported_scheme(monkeypatch):
 
 def test_warn_silent_for_supported_scheme(monkeypatch):
     """No warning when the scheme is in the list."""
-    monkeypatch.setattr(skvideo, "_FFMPEG_INPUT_PROTOCOLS", ["file", "http", "https"])
-    monkeypatch.setattr(skvideo, "_FFMPEG_OUTPUT_PROTOCOLS", ["file"])
+    monkeypatch.setattr(skvideo, "_FFMPEG_PROTOCOLS", (["file", "http", "https"], ["file"]))
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
@@ -98,8 +118,7 @@ def test_warn_silent_for_supported_scheme(monkeypatch):
 
 def test_warn_silent_when_detection_failed(monkeypatch):
     """Empty protocol list = detection failed; don't preempt ffmpeg's error."""
-    monkeypatch.setattr(skvideo, "_FFMPEG_INPUT_PROTOCOLS", [])
-    monkeypatch.setattr(skvideo, "_FFMPEG_OUTPUT_PROTOCOLS", [])
+    monkeypatch.setattr(skvideo, "_FFMPEG_PROTOCOLS", ([], []))
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
@@ -111,8 +130,7 @@ def test_warn_silent_when_detection_failed(monkeypatch):
 
 def test_warn_silent_for_non_url(monkeypatch):
     """Plain filenames (no `://`) don't trigger the URL warning."""
-    monkeypatch.setattr(skvideo, "_FFMPEG_INPUT_PROTOCOLS", ["file"])
-    monkeypatch.setattr(skvideo, "_FFMPEG_OUTPUT_PROTOCOLS", ["file"])
+    monkeypatch.setattr(skvideo, "_FFMPEG_PROTOCOLS", (["file"], ["file"]))
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
@@ -125,8 +143,7 @@ def test_warn_silent_for_non_url(monkeypatch):
 
 def test_warn_input_vs_output_independent(monkeypatch):
     """A scheme supported as output but not input should warn for input only."""
-    monkeypatch.setattr(skvideo, "_FFMPEG_INPUT_PROTOCOLS", ["file"])
-    monkeypatch.setattr(skvideo, "_FFMPEG_OUTPUT_PROTOCOLS", ["file", "md5"])
+    monkeypatch.setattr(skvideo, "_FFMPEG_PROTOCOLS", (["file"], ["file", "md5"]))
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
@@ -143,14 +160,11 @@ def test_warn_input_vs_output_independent(monkeypatch):
 def test_setffmpegpath_invalidates_protocol_cache(monkeypatch):
     """A new ffmpeg binary may have different compiled-in protocols, so
     setFFmpegPath must clear the cache."""
-    # Pre-populate the cache as if detection ran
-    monkeypatch.setattr(skvideo, "_FFMPEG_INPUT_PROTOCOLS", ["file"])
-    monkeypatch.setattr(skvideo, "_FFMPEG_OUTPUT_PROTOCOLS", ["file"])
+    monkeypatch.setattr(skvideo, "_FFMPEG_PROTOCOLS", (["file"], ["file"]))
 
     original_path = skvideo.getFFmpegPath()
     try:
         skvideo.setFFmpegPath("/")  # any path; we just need the cache reset
-        assert skvideo._FFMPEG_INPUT_PROTOCOLS is None
-        assert skvideo._FFMPEG_OUTPUT_PROTOCOLS is None
+        assert skvideo._FFMPEG_PROTOCOLS is None
     finally:
         skvideo.setFFmpegPath(original_path)

--- a/skvideo/tests/test_protocol_detection.py
+++ b/skvideo/tests/test_protocol_detection.py
@@ -1,0 +1,156 @@
+"""Tests for ffmpeg protocol detection + warning (v1.1.14)."""
+import warnings
+
+import pytest
+
+import skvideo
+
+
+# --- parser unit tests -------------------------------------------------------
+
+def test_parser_extracts_input_and_output_protocols(monkeypatch):
+    """Parse a representative `ffmpeg -protocols` payload and confirm
+    both sections are extracted."""
+    fake_output = (
+        b"Supported file protocols:\n"
+        b"Input:\n"
+        b"  file\n"
+        b"  http\n"
+        b"  https\n"
+        b"  pipe\n"
+        b"  rtsp\n"
+        b"Output:\n"
+        b"  file\n"
+        b"  http\n"
+        b"  md5\n"
+        b"  pipe\n"
+    )
+    monkeypatch.setattr(skvideo, "_FFMPEG_INPUT_PROTOCOLS", None)
+    monkeypatch.setattr(skvideo, "_FFMPEG_OUTPUT_PROTOCOLS", None)
+    monkeypatch.setattr(skvideo, "check_output", lambda *a, **k: fake_output)
+
+    inputs, outputs = skvideo._get_ffmpeg_protocols()
+    assert set(inputs) == {"file", "http", "https", "pipe", "rtsp"}
+    assert set(outputs) == {"file", "http", "md5", "pipe"}
+
+
+def test_parser_caches_result(monkeypatch):
+    """Second call should NOT re-invoke check_output (lazy cache)."""
+    call_count = {"n": 0}
+
+    def fake_check_output(*a, **k):
+        call_count["n"] += 1
+        return b"Supported file protocols:\nInput:\n  file\nOutput:\n  file\n"
+
+    monkeypatch.setattr(skvideo, "_FFMPEG_INPUT_PROTOCOLS", None)
+    monkeypatch.setattr(skvideo, "_FFMPEG_OUTPUT_PROTOCOLS", None)
+    monkeypatch.setattr(skvideo, "check_output", fake_check_output)
+
+    skvideo._get_ffmpeg_protocols()
+    skvideo._get_ffmpeg_protocols()
+    skvideo._get_ffmpeg_protocols()
+    assert call_count["n"] == 1, "expected one cached invocation, got %d" % call_count["n"]
+
+
+def test_parser_handles_detection_failure(monkeypatch):
+    """If check_output raises, return empty lists rather than propagating."""
+    def boom(*a, **k):
+        raise OSError("ffmpeg crashed")
+
+    monkeypatch.setattr(skvideo, "_FFMPEG_INPUT_PROTOCOLS", None)
+    monkeypatch.setattr(skvideo, "_FFMPEG_OUTPUT_PROTOCOLS", None)
+    monkeypatch.setattr(skvideo, "check_output", boom)
+
+    inputs, outputs = skvideo._get_ffmpeg_protocols()
+    assert inputs == []
+    assert outputs == []
+
+
+# --- warn behavior tests -----------------------------------------------------
+
+def test_warn_fires_for_unsupported_scheme(monkeypatch):
+    """When the URL scheme isn't in the supported list, a UserWarning fires."""
+    monkeypatch.setattr(skvideo, "_FFMPEG_INPUT_PROTOCOLS", ["file", "http", "pipe"])
+    monkeypatch.setattr(skvideo, "_FFMPEG_OUTPUT_PROTOCOLS", ["file", "pipe"])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        skvideo._warn_if_unsupported_protocol("https://example.com/x.mp4", "input")
+
+    msgs = [str(w.message) for w in caught if issubclass(w.category, UserWarning)]
+    assert msgs, "Expected a UserWarning for unsupported https scheme"
+    assert "https" in msgs[0]
+    assert "input" in msgs[0]
+
+
+def test_warn_silent_for_supported_scheme(monkeypatch):
+    """No warning when the scheme is in the list."""
+    monkeypatch.setattr(skvideo, "_FFMPEG_INPUT_PROTOCOLS", ["file", "http", "https"])
+    monkeypatch.setattr(skvideo, "_FFMPEG_OUTPUT_PROTOCOLS", ["file"])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        skvideo._warn_if_unsupported_protocol("https://example.com/x.mp4", "input")
+
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert not user_warnings, "Did not expect warning; got %r" % user_warnings
+
+
+def test_warn_silent_when_detection_failed(monkeypatch):
+    """Empty protocol list = detection failed; don't preempt ffmpeg's error."""
+    monkeypatch.setattr(skvideo, "_FFMPEG_INPUT_PROTOCOLS", [])
+    monkeypatch.setattr(skvideo, "_FFMPEG_OUTPUT_PROTOCOLS", [])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        skvideo._warn_if_unsupported_protocol("https://example.com/x.mp4", "input")
+
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert not user_warnings
+
+
+def test_warn_silent_for_non_url(monkeypatch):
+    """Plain filenames (no `://`) don't trigger the URL warning."""
+    monkeypatch.setattr(skvideo, "_FFMPEG_INPUT_PROTOCOLS", ["file"])
+    monkeypatch.setattr(skvideo, "_FFMPEG_OUTPUT_PROTOCOLS", ["file"])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        skvideo._warn_if_unsupported_protocol("/tmp/video.mp4", "input")
+        skvideo._warn_if_unsupported_protocol("video.mp4", "input")
+
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert not user_warnings
+
+
+def test_warn_input_vs_output_independent(monkeypatch):
+    """A scheme supported as output but not input should warn for input only."""
+    monkeypatch.setattr(skvideo, "_FFMPEG_INPUT_PROTOCOLS", ["file"])
+    monkeypatch.setattr(skvideo, "_FFMPEG_OUTPUT_PROTOCOLS", ["file", "md5"])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        skvideo._warn_if_unsupported_protocol("md5://output.bin", "input")
+        skvideo._warn_if_unsupported_protocol("md5://output.bin", "output")
+
+    msgs = [str(w.message) for w in caught if issubclass(w.category, UserWarning)]
+    assert len(msgs) == 1, "Expected exactly one warning (input only); got %d" % len(msgs)
+    assert "input" in msgs[0]
+
+
+# --- integration with setFFmpegPath ------------------------------------------
+
+def test_setffmpegpath_invalidates_protocol_cache(monkeypatch):
+    """A new ffmpeg binary may have different compiled-in protocols, so
+    setFFmpegPath must clear the cache."""
+    # Pre-populate the cache as if detection ran
+    monkeypatch.setattr(skvideo, "_FFMPEG_INPUT_PROTOCOLS", ["file"])
+    monkeypatch.setattr(skvideo, "_FFMPEG_OUTPUT_PROTOCOLS", ["file"])
+
+    original_path = skvideo.getFFmpegPath()
+    try:
+        skvideo.setFFmpegPath("/")  # any path; we just need the cache reset
+        assert skvideo._FFMPEG_INPUT_PROTOCOLS is None
+        assert skvideo._FFMPEG_OUTPUT_PROTOCOLS is None
+    finally:
+        skvideo.setFFmpegPath(original_path)

--- a/skvideo/tests/test_source_classification.py
+++ b/skvideo/tests/test_source_classification.py
@@ -1,0 +1,75 @@
+"""Tests for the input/output source classifier (issues #117, #113, #81)."""
+import io
+from pathlib import Path
+
+import pytest
+
+from skvideo.io.abstract import _classify_source
+
+
+# --- "file" category ---------------------------------------------------------
+
+def test_plain_string_filename_is_file():
+    assert _classify_source("video.mp4") == "file"
+
+
+def test_string_with_directory_is_file():
+    assert _classify_source("/tmp/clip.mov") == "file"
+
+
+def test_pathlib_path_is_file():
+    assert _classify_source(Path("/tmp/clip.mov")) == "file"
+
+
+def test_windows_drive_letter_is_file():
+    # Strict URL regex requires `<scheme>://`. `C:\foo.mp4` has no slashes,
+    # so it must not be mistaken for a URL.
+    assert _classify_source(r"C:\videos\clip.mp4") == "file"
+
+
+def test_relative_filename_is_file():
+    assert _classify_source("clip.mp4") == "file"
+
+
+# --- "url" category ----------------------------------------------------------
+
+@pytest.mark.parametrize("url", [
+    "http://example.com/video.mp4",
+    "https://example.com/video.mp4",
+    "rtsp://camera.local:554/stream",
+    "rtmp://server/live/key",
+    "rtmps://server/live/key",
+    "udp://127.0.0.1:1234",
+    "tcp://127.0.0.1:1234",
+    "ftp://example.com/clip.mp4",
+    "sftp://example.com/clip.mp4",
+    "srt://server:9000",
+    "hls://example.com/stream.m3u8",
+])
+def test_known_url_schemes_classify_as_url(url):
+    assert _classify_source(url) == "url"
+
+
+# --- "memory" category -------------------------------------------------------
+
+def test_bytesio_is_memory():
+    assert _classify_source(io.BytesIO(b"some bytes")) == "memory"
+
+
+def test_open_file_handle_is_memory():
+    """An already-open file handle (has read()) classifies as memory."""
+    with open(__file__, "rb") as fh:
+        assert _classify_source(fh) == "memory"
+
+
+def test_bytesio_for_writing_is_memory():
+    """A BytesIO opened for writing also classifies as memory (has write())."""
+    buf = io.BytesIO()
+    assert _classify_source(buf) == "memory"
+
+
+# --- edge cases --------------------------------------------------------------
+
+def test_empty_string_is_file():
+    """Defer to existing error handling; don't mis-classify."""
+    assert _classify_source("") == "file"

--- a/skvideo/tests/test_url_input.py
+++ b/skvideo/tests/test_url_input.py
@@ -1,0 +1,138 @@
+"""Tests for URL input support (issues #117, #81).
+
+Uses a local Range-aware HTTP server fixture so we don't depend on external
+network. Python's stdlib SimpleHTTPRequestHandler does NOT implement the
+Range header, which ffmpeg's HTTP reader requires to seek the mp4 moov atom —
+without proper Range support ffmpeg gets "partial file" errors and silently
+returns empty frames.
+"""
+import http.server
+import os
+import socketserver
+import threading
+
+import pytest
+
+import skvideo.io
+import skvideo.datasets
+
+
+class _RangeHandler(http.server.SimpleHTTPRequestHandler):
+    """SimpleHTTPRequestHandler + minimal RFC 7233 Range support.
+
+    Enough to satisfy ffmpeg's HTTP demuxer (single byte-range form
+    `Range: bytes=START-END` or `Range: bytes=START-`). Returns 206
+    Partial Content for valid ranges, falls back to the parent's 200
+    response when no Range header is present.
+    """
+
+    def log_message(self, format, *args):  # silence per-request logs
+        pass
+
+    def send_head(self):
+        rng = self.headers.get("Range")
+        if not rng or not rng.startswith("bytes="):
+            return super().send_head()
+        # Parse "bytes=START-END" (END optional)
+        try:
+            start_s, end_s = rng[len("bytes="):].split("-", 1)
+            start = int(start_s)
+            path = self.translate_path(self.path)
+            size = os.path.getsize(path)
+            end = int(end_s) if end_s else size - 1
+            if start >= size or end >= size or start > end:
+                self.send_error(416, "Requested Range Not Satisfiable")
+                return None
+            length = end - start + 1
+            f = open(path, "rb")
+            f.seek(start)
+            self.send_response(206)
+            self.send_header("Content-Type", self.guess_type(path))
+            self.send_header("Accept-Ranges", "bytes")
+            self.send_header("Content-Range", "bytes %d-%d/%d" % (start, end, size))
+            self.send_header("Content-Length", str(length))
+            self.end_headers()
+            # Stream just the requested slice. Parent's copyfile reads until EOF;
+            # we cap at `length` bytes manually.
+            try:
+                remaining = length
+                while remaining > 0:
+                    chunk = f.read(min(64 * 1024, remaining))
+                    if not chunk:
+                        break
+                    self.wfile.write(chunk)
+                    remaining -= len(chunk)
+            finally:
+                f.close()
+            return None  # we already wrote the body
+        except (ValueError, OSError):
+            self.send_error(400, "Bad Range header")
+            return None
+
+
+@pytest.fixture(scope="module")
+def local_http_server():
+    """Serve skvideo's datasets directory on a free port with Range support.
+
+    Yields the base URL (e.g. http://127.0.0.1:38123/). Skips if no port can
+    be bound (rare; happens on locked-down CI).
+    """
+    datasets_dir = os.path.dirname(skvideo.datasets.bigbuckbunny())
+
+    class _Handler(_RangeHandler):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, directory=datasets_dir, **kwargs)
+
+    try:
+        # ThreadingTCPServer: ffmpeg may issue multiple concurrent Range
+        # requests; a single-threaded server stalls them.
+        server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), _Handler)
+        server.daemon_threads = True
+    except OSError as exc:
+        pytest.skip("Could not bind local HTTP server: %s" % exc)
+
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield "http://127.0.0.1:%d/" % port
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_vread_accepts_http_url(local_http_server):
+    """vread() with an http:// URL should download via ffmpeg and decode."""
+    url = local_http_server + "bigbuckbunny.mp4"
+    videodata = skvideo.io.vread(url, num_frames=3)
+    assert videodata.shape == (3, 720, 1280, 3)
+
+
+def test_ffmpegreader_accepts_http_url(local_http_server):
+    """FFmpegReader directly should also work; previously crashed on
+    os.path.getsize() at abstract.py:79.
+    """
+    url = local_http_server + "bigbuckbunny.mp4"
+    reader = skvideo.io.FFmpegReader(url)
+    try:
+        shape = reader.getShape()
+        assert shape[1:] == (720, 1280, 3)  # H, W, C — frame count may vary
+        # Read up to a few frames to confirm the pipe works. Use for-break
+        # rather than next() to avoid PEP 479 StopIteration RuntimeError if
+        # the URL is treated as a webcam-style stream (inputframenum=0).
+        first_frame = None
+        for frame in reader.nextFrame():
+            first_frame = frame
+            break
+        assert first_frame is not None, "Reader yielded no frames"
+        assert first_frame.shape == (720, 1280, 3)
+    finally:
+        reader.close()
+
+
+def test_ffprobe_accepts_http_url(local_http_server):
+    """ffprobe natively supports http; verify our wrapper doesn't break that."""
+    url = local_http_server + "bigbuckbunny.mp4"
+    info = skvideo.io.ffprobe(url)
+    assert info != {}, "ffprobe returned empty for valid http URL"
+    assert "video" in info

--- a/skvideo/tests/test_url_output.py
+++ b/skvideo/tests/test_url_output.py
@@ -1,0 +1,62 @@
+"""Tests for URL output support (issue #117 write-side, related #81).
+
+Full end-to-end URL output (e.g. rtmp publish, HTTP PUT) depends on a
+cooperating server that handles ffmpeg's chunked streaming behavior — that
+infrastructure is heavier than v1.1.14 needs. The wrapper's actual guarantee
+is narrower: "don't block construction on the URL string." That's what these
+tests verify.
+"""
+import io as _io
+
+import pytest
+
+import skvideo.io
+
+
+def test_ffmpegwriter_accepts_rtmp_url_without_crashing():
+    """Before commit 4, constructing a writer with rtmp:// crashed with
+    `AssertionError: Cannot write to directory:` because os.path.split on
+    `rtmp://host/path` returns ('rtmp:', '/host/path'), and os.access on
+    'rtmp:' fails. Now URLs skip the writable-directory check entirely.
+    """
+    writer = skvideo.io.FFmpegWriter(
+        "rtmp://example.invalid/live/stream",
+        outputdict={"-f": "flv"},
+    )
+    # Don't call writeFrame — that would try to connect to the invalid
+    # rtmp host. The wrapper-side guarantee is just "construction works".
+    assert writer._dest_kind == "url"
+    writer.close()
+
+
+def test_ffmpegwriter_accepts_http_url_without_crashing():
+    """Same guarantee for http:// destinations (PUT-style publish)."""
+    writer = skvideo.io.FFmpegWriter(
+        "http://example.invalid/upload.mp4",
+        outputdict={"-method": "PUT", "-f": "mp4"},
+    )
+    assert writer._dest_kind == "url"
+    writer.close()
+
+
+def test_writer_url_skips_extension_assert():
+    """URLs have no meaningful extension on the wrapper side; the encoder
+    allowlist assertion must not fire (the URL might end in a path with
+    no extension at all)."""
+    # Would have failed previously: os.path.splitext on
+    # 'rtmp://server/live/stream' yields extension '', which isn't in the
+    # supported encoders allowlist.
+    writer = skvideo.io.FFmpegWriter(
+        "rtmp://server/live/stream",
+        outputdict={"-f": "flv"},
+    )
+    assert writer.extension == ""  # documented as "" for non-file destinations
+    writer.close()
+
+
+def test_writer_rejects_bytesio_for_now():
+    """Until commit 5 wires up BytesIO output, the wrapper should refuse
+    cleanly rather than crash mid-init with a confusing error."""
+    buf = _io.BytesIO()
+    with pytest.raises(NotImplementedError, match="BytesIO"):
+        skvideo.io.FFmpegWriter(buf)

--- a/skvideo/tests/test_url_output.py
+++ b/skvideo/tests/test_url_output.py
@@ -65,3 +65,17 @@ def test_writer_rejects_non_file_like_memory_dest():
             return b""
     with pytest.raises(TypeError, match="write"):
         skvideo.io.FFmpegWriter(_ReadOnly())
+
+
+def test_writer_close_releases_devnull():
+    """A writer constructed but never warm-started (no frames written) must
+    still release the DEVNULL handle opened in __init__. URL/validation-only
+    writers hit close() with _proc is None; if that path returns early
+    without closing DEVNULL, every such writer leaks a file descriptor."""
+    writer = skvideo.io.FFmpegWriter(
+        "rtmp://example.invalid/live/stream",
+        outputdict={"-f": "flv"},
+    )
+    assert writer._proc is None  # never warm-started
+    writer.close()
+    assert writer.DEVNULL.closed

--- a/skvideo/tests/test_url_output.py
+++ b/skvideo/tests/test_url_output.py
@@ -54,9 +54,14 @@ def test_writer_url_skips_extension_assert():
     writer.close()
 
 
-def test_writer_rejects_bytesio_for_now():
-    """Until commit 5 wires up BytesIO output, the wrapper should refuse
-    cleanly rather than crash mid-init with a confusing error."""
-    buf = _io.BytesIO()
-    with pytest.raises(NotImplementedError, match="BytesIO"):
-        skvideo.io.FFmpegWriter(buf)
+def test_writer_rejects_non_file_like_memory_dest():
+    """Memory destinations must expose .write(). Plain str passes the
+    URL/file branch; only objects without write() should trip here."""
+    # Pick something that hasattr('read') (so memory branch fires) but
+    # not write(). io.IOBase doesn't help — easiest is to construct one
+    # manually.
+    class _ReadOnly:
+        def read(self, n=-1):
+            return b""
+    with pytest.raises(TypeError, match="write"):
+        skvideo.io.FFmpegWriter(_ReadOnly())

--- a/skvideo/utils/__init__.py
+++ b/skvideo/utils/__init__.py
@@ -343,10 +343,13 @@ def rgb2gray(videodata):
     if C == 1:
         return videodata
     elif C == 3: # assume RGB
-        videodata = videodata[:, :, :, 0]*0.2989 + videodata[:, :, :, 1]*0.5870 + videodata[:, :, :, 2]*0.1140 
+        videodata = videodata[:, :, :, 0]*0.2989 + videodata[:, :, :, 1]*0.5870 + videodata[:, :, :, 2]*0.1140
         return vshape(videodata)
     else:
-        raise NotImplemented
+        raise NotImplementedError(
+            "rgb2gray only supports 1-channel (grayscale) or 3-channel "
+            "(RGB) input; got %d channels." % C
+        )
 
 __all__ = [
     'xmltodictparser',

--- a/skvideo/utils/edge.py
+++ b/skvideo/utils/edge.py
@@ -152,7 +152,7 @@ def canny(frame):
         return low_mask
 
     sums = (np.array(scipy.ndimage.sum(high_mask, labels,
-                             np.arange(count, dtype=int32) + 1),
+                             np.arange(count, dtype=np.int32) + 1),
                      copy=False, ndmin=1))
     good_label = np.zeros((count + 1,), bool)
     good_label[1:] = sums > 0


### PR DESCRIPTION
## Summary

v1.1.14 release. Two themes:

1. **Non-local I/O** — `vread`/`vreader`/`vwrite` and the `FFmpegReader`/`FFmpegWriter` constructors now accept file paths, URL strings, and file-like objects (`io.BytesIO`) uniformly. Closes #117, #113, related #81. Plus protocol-support warnings for URL schemes the local ffmpeg lacks.

2. **Python-3 correctness + hardening** — a whole-codebase pass fixing pre-existing defects (none introduced by the I/O work): `Li3DDCT_features`/`canny` `int32` `NameError` crashes, `globalEdgeMotion` + `blockComp` motion bugs, `from skvideo import *` `TypeError`, `exit()`/`NotImplemented` removal, `assert`→exception for public input validation (survives `python -O`), probe-failure warnings, and edge-case fixes (shape/grid validation, non-divisible `blockComp` borders, zero-frame `vwrite`).

Also documentation fixes to the I/O guide: #186 (writer framerate belongs in `inputdict`), #143 (alpha-channel recipe), and the `select`/`-vsync 0` frame-exact recipe.

Deferred to v1.1.15: #172 (VFR), PR #131 (compare_videos), a full backend/parse `assert` sweep, per-metric minimum-size guards, and metric reference-dataset validation.

## Test plan

- Full suite: 167 passed / 16 skipped / 0 failed (Python 3.12, ffmpeg 8.1). CI matrix is Python 3.10–3.13 x Linux/macOS.
- `twine check`: PASSED (wheel + sdist).
- End-to-end functional check on real video: read/write/round-trip (incl. BytesIO), all quality metrics, scene detection, motion estimation + compensation all working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)