### PR TITLE
v1.1.15: correctness completion (assert sweep, ssim guard, py2 cleanup)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,16 @@
 1.1.15 (unreleased)
 -------------------
-- **Correctness completion pass.** Continues the v1.1.14 hardening: remaining
-  user-facing ``assert`` validation converted to real exceptions, per-metric
-  minimum-size guards, and residual Python-2 cleanup. (in progress)
+Correctness-completion pass continuing the v1.1.14 hardening:
+
+- Remaining user-facing ``assert`` validation now raises real exceptions
+  (survives ``python -O``): backend-availability checks (FFmpeg / libav /
+  mediainfo and the libav version) raise ``RuntimeError``; ``mprobe`` XML-parse
+  guards and the ``utils.mscn`` / ``utils.image`` input checks raise
+  ``ValueError``. Only internal ``self._proc is not None`` invariants remain
+  as asserts.
+- ``ssim`` now raises ``ValueError`` for frames smaller than its 11x11 window
+  instead of silently returning ``NaN``.
+- Ported the last Python-2 ``xrange`` (``utils/stpyr.py``) to ``range``.
 
 1.1.14 (2026-06-02)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-1.1.15 (unreleased)
+1.1.15 (2026-06-02)
 -------------------
 Correctness-completion pass continuing the v1.1.14 hardening:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,15 @@ Correctness-completion pass continuing the v1.1.14 hardening:
 - ``ssim`` now raises ``ValueError`` for frames smaller than its 11x11 window
   instead of silently returning ``NaN``.
 - Ported the last Python-2 ``xrange`` (``utils/stpyr.py``) to ``range``.
+- Reading an empty or undecodable memory/file source via the count-frames
+  fallback now raises a clear ``RuntimeError`` explaining the input is
+  unreadable (and how to declare the frame count) instead of leaking a raw
+  ``subprocess.CalledProcessError``.
+- ``FFmpegReader.close`` now closes its pipe file objects even when ffmpeg has
+  already exited (e.g. ``start_frame`` seeks past EOF), removing a spurious
+  ``ResourceWarning``.
+- Docs: corrected the full-reference metric reference from the removed ``mad``
+  to ``mae`` in ``doc/measure.rst`` and the module autosummary.
 
 1.1.14 (2026-06-02)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+1.1.15 (unreleased)
+-------------------
+- **Correctness completion pass.** Continues the v1.1.14 hardening: remaining
+  user-facing ``assert`` validation converted to real exceptions, per-metric
+  minimum-size guards, and residual Python-2 cleanup. (in progress)
+
 1.1.14 (2026-06-02)
 -------------------
 - **Input source decoupling**: ``vread`` / ``vreader`` / ``vwrite`` and the

--- a/README.rst
+++ b/README.rst
@@ -76,15 +76,19 @@ Then check that ``skvideo`` resolves to the expected location::
     print(skvideo.__file__)
 
 
-What's new in 1.1.14
+What's new in 1.1.15
 --------------------
 
-scikit-video is actively maintained again. The 1.1.12–1.1.14 line modernizes
+scikit-video is actively maintained again. The 1.1.12–1.1.15 line modernizes
 the package for current Python (3.10–3.13), NumPy 2.x, and SciPy, with **no
-breaking API changes** — code that worked with 1.1.11 should continue to work
-unchanged. Highlights of 1.1.14:
+breaking API changes**; code that worked with 1.1.11 should continue to work
+unchanged. Highlights:
 
-- **Non-local I/O.** ``vread`` / ``vreader`` / ``vwrite`` and the
+- **Correctness completion (1.1.15).** Remaining user-facing ``assert``
+  validation now raises real exceptions (so it survives ``python -O``);
+  ``ssim`` rejects sub-window-size frames instead of returning ``NaN``; last
+  Python-2 ``xrange`` removed.
+- **Non-local I/O (1.1.14).** ``vread`` / ``vreader`` / ``vwrite`` and the
   ``FFmpegReader`` / ``FFmpegWriter`` constructors now accept file paths, URL
   strings (``http://``, ``https://``, ``rtsp://``, ...), and file-like objects
   (``io.BytesIO``) interchangeably (issues #117, #113, #81). A ``UserWarning``

--- a/doc/measure.rst
+++ b/doc/measure.rst
@@ -29,7 +29,7 @@ Use :func:`skvideo.measure.ssim` to measure the perceptually quality difference 
 
 Use :func:`skvideo.measure.msssim` to measure the perceptually quality difference between two videos, considering only individual frames. Differs from ssim in that this function considers multiple scales.
 
-Use :func:`skvideo.measure.mse`, :func:`skvideo.measure.mad`, or :func:`skvideo.measure.psnr` to measure simple point-wise similarity between two videos.
+Use :func:`skvideo.measure.mse`, :func:`skvideo.measure.mae`, or :func:`skvideo.measure.psnr` to measure simple point-wise similarity between two videos.
 
 No-Reference Quality Assessment
 ---------------------------------

--- a/doc/measure.rst
+++ b/doc/measure.rst
@@ -8,6 +8,14 @@ Measurement Tools
 
 :mod:`skvideo.measure` provides quality assessment tools, scene detection, and other measurement operations.
 
+.. note::
+
+   The quality metrics assume **finite, real-valued pixel data**. Non-finite
+   input (``NaN`` / ``inf``) is the caller's responsibility; it is not
+   rejected and will propagate into non-finite scores. Sanitize your input
+   (e.g. with ``np.nan_to_num``) before measuring if it may contain
+   non-finite values.
+
 Reduced-Reference Quality Assessment
 ------------------------------------
 

--- a/doc/modules/measure.rst
+++ b/doc/modules/measure.rst
@@ -23,7 +23,7 @@ Functions
    ssim
    msssim
    mse
-   mad
+   mae
    psnr
    scenedet
    brisque_features

--- a/skvideo/__init__.py
+++ b/skvideo/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.15.dev0"
+__version__ = "1.1.15"
 
 from .utils import check_output, where
 import os

--- a/skvideo/__init__.py
+++ b/skvideo/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.14"
+__version__ = "1.1.15.dev0"
 
 from .utils import check_output, where
 import os

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -468,12 +468,20 @@ class VideoReaderAbstract(object):
         return self.inputframenum, self.outputheight, self.outputwidth, self.outputdepth
 
     def close(self):
-        if self._proc is not None and self._proc.poll() is None:
-            self._proc.stdin.close()
-            self._proc.stdout.close()
+        if self._proc is not None:
+            # Close the pipe file objects regardless of process state. If
+            # ffmpeg already exited (e.g. start_frame seeks past EOF), the
+            # pipes are still open Python file objects and skipping them
+            # leaks a ResourceWarning. Only a still-running process needs
+            # terminating.
+            if self._proc.stdin is not None:
+                self._proc.stdin.close()
+            if self._proc.stdout is not None:
+                self._proc.stdout.close()
             if self._proc.stderr is not None:
                 self._proc.stderr.close()
-            self._terminate(0.2)
+            if self._proc.poll() is None:
+                self._terminate(0.2)
         self._proc = None
         # Clean up the spooled temp file for memory sources (issue #113).
         # Best-effort: ignore if already removed or unreachable.

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -155,7 +155,8 @@ class VideoReaderAbstract(object):
 
         """
         # check if FFMPEG exists in the path
-        assert _HAS_FFMPEG, "Cannot find installation of real FFmpeg (which comes with ffprobe)."
+        if not _HAS_FFMPEG:
+            raise RuntimeError("Cannot find installation of real FFmpeg (which comes with ffprobe).")
 
         self._source_kind = _classify_source(filename)
         # Track temp files spooled from memory sources so close() can clean

--- a/skvideo/io/avconv.py
+++ b/skvideo/io/avconv.py
@@ -36,7 +36,8 @@ class LibAVReader(VideoReaderAbstract):
     OUTPUT_METHOD = "rawvideo"
 
     def __init__(self, *args, **kwargs):
-        assert _HAS_AVCONV, "Cannot find installation of libav (which comes with avprobe)."
+        if not _HAS_AVCONV:
+            raise RuntimeError("Cannot find installation of libav (which comes with avprobe).")
         super(LibAVReader,self).__init__(*args, **kwargs)
 
     def _createProcess(self, inputdict, outputdict, verbosity):
@@ -74,7 +75,8 @@ class LibAVWriter(VideoWriterAbstract):
     """
 
     def __init__(self, *args, **kwargs):
-        assert _HAS_AVCONV, "Cannot find installation of libav (which comes with avprobe)."
+        if not _HAS_AVCONV:
+            raise RuntimeError("Cannot find installation of libav (which comes with avprobe).")
         super(LibAVWriter,self).__init__(*args, **kwargs)
 
     def _createProcess(self, inputdict, outputdict, verbosity):

--- a/skvideo/io/avconv.py
+++ b/skvideo/io/avconv.py
@@ -57,11 +57,27 @@ class LibAVReader(VideoReaderAbstract):
                                   stdout=sp.PIPE, stderr=None)
 
     def _probCountFrames(self):
-        # open process, grabbing number of frames using ffprobe
+        # open process, grabbing number of frames using avprobe
         probecmd = [_AVCONV_PATH + "/avprobe"] + ["-v", "error", "-count_frames", "-select_streams", "v:0",
                                                   "-show_entries", "stream=nb_read_frames", "-of",
                                                   "default=nokey=1:noprint_wrappers=1", self._filename]
-        return int(check_output(probecmd).decode().split('\n')[0])
+        try:
+            output = check_output(probecmd).decode().split('\n')[0]
+        except sp.CalledProcessError:
+            raise RuntimeError(
+                "Could not count the frames of %r: avprobe could not read it. "
+                "The input is most likely empty, truncated, or not a video "
+                "that libav can decode. For raw video pass -s and -pix_fmt "
+                "(and ideally -vframes) in inputdict." % self._filename
+            )
+        try:
+            return int(output)
+        except ValueError:
+            raise RuntimeError(
+                "Could not count the frames of %r: avprobe returned no frame "
+                "count (%r). Pass -vframes in inputdict to declare the frame "
+                "count explicitly." % (self._filename, output)
+            )
 
     def _probe(self):
         return avprobe(self._filename)

--- a/skvideo/io/avprobe.py
+++ b/skvideo/io/avprobe.py
@@ -30,7 +30,7 @@ def avprobe(filename):
     if not _HAS_AVCONV:
         raise RuntimeError("Cannot find installation of avprobe.")
     if int(_LIBAV_MAJOR_VERSION) < 10:
-        raise RuntimeError("Version of libav (" + str(_LIBAV_MAJOR_VERSION) + ") < 9. Please update libav or use ffmpeg.")
+        raise RuntimeError("Version of libav (" + str(_LIBAV_MAJOR_VERSION) + ") is too old (need >= 10). Please update libav or use ffmpeg.")
 
     try:
         command = [_AVCONV_PATH + "/" + _AVPROBE_APPLICATION, "-v", "error", "-show_streams", "-of", "json", filename]

--- a/skvideo/io/avprobe.py
+++ b/skvideo/io/avprobe.py
@@ -27,8 +27,10 @@ def avprobe(filename):
 
     """
     # check if FFMPEG exists in the path
-    assert _HAS_AVCONV, "Cannot find installation of avprobe."
-    assert int(_LIBAV_MAJOR_VERSION) >= 10, "Version of libav (" + str(_LIBAV_MAJOR_VERSION) +") < 9. Please update libav or use ffmpeg."
+    if not _HAS_AVCONV:
+        raise RuntimeError("Cannot find installation of avprobe.")
+    if int(_LIBAV_MAJOR_VERSION) < 10:
+        raise RuntimeError("Version of libav (" + str(_LIBAV_MAJOR_VERSION) + ") < 9. Please update libav or use ffmpeg.")
 
     try:
         command = [_AVCONV_PATH + "/" + _AVPROBE_APPLICATION, "-v", "error", "-show_streams", "-of", "json", filename]

--- a/skvideo/io/ffmpeg.py
+++ b/skvideo/io/ffmpeg.py
@@ -70,7 +70,23 @@ class FFmpegReader(VideoReaderAbstract):
         probecmd = [_FFMPEG_PATH + "/ffprobe"] + ["-v", "error", "-count_frames", "-select_streams", "v:0",
                                                   "-show_entries", "stream=nb_read_frames", "-of",
                                                   "default=nokey=1:noprint_wrappers=1", self._filename]
-        return int(check_output(probecmd).decode().split('\n')[0])
+        try:
+            output = check_output(probecmd).decode().split('\n')[0]
+        except sp.CalledProcessError:
+            raise RuntimeError(
+                "Could not count the frames of %r: ffprobe could not read it. "
+                "The input is most likely empty, truncated, or not a video "
+                "that ffmpeg can decode. For raw video pass -s and -pix_fmt "
+                "(and ideally -vframes) in inputdict." % self._filename
+            )
+        try:
+            return int(output)
+        except ValueError:
+            raise RuntimeError(
+                "Could not count the frames of %r: ffprobe returned no frame "
+                "count (%r). Pass -vframes in inputdict to declare the frame "
+                "count explicitly." % (self._filename, output)
+            )
 
     def _probe(self):
         return ffprobe(self._filename)

--- a/skvideo/io/ffmpeg.py
+++ b/skvideo/io/ffmpeg.py
@@ -41,7 +41,8 @@ class FFmpegReader(VideoReaderAbstract):
     OUTPUT_METHOD = "image2pipe"
 
     def __init__(self, *args, **kwargs):
-        assert _HAS_FFMPEG, "Cannot find installation of real FFmpeg (which comes with ffprobe)."
+        if not _HAS_FFMPEG:
+            raise RuntimeError("Cannot find installation of real FFmpeg (which comes with ffprobe).")
         super(FFmpegReader,self).__init__(*args, **kwargs)
 
     def _createProcess(self, inputdict, outputdict, verbosity):
@@ -139,7 +140,8 @@ class FFmpegWriter(VideoWriterAbstract):
 
     def __init__(self, filename, inputdict=None, outputdict=None,
                  audiosrc=None, verbosity=0):
-        assert _HAS_FFMPEG, "Cannot find installation of real FFmpeg (which comes with ffprobe)."
+        if not _HAS_FFMPEG:
+            raise RuntimeError("Cannot find installation of real FFmpeg (which comes with ffprobe).")
         if audiosrc is not None:
             # Fail fast at construction time rather than letting ffmpeg
             # produce a silent videoless output that the user discovers

--- a/skvideo/io/ffprobe.py
+++ b/skvideo/io/ffprobe.py
@@ -42,7 +42,8 @@ def ffprobe(filename):
 
     """
     # check if FFMPEG exists in the path
-    assert _HAS_FFMPEG, "Cannot find installation of real FFmpeg (which comes with ffprobe)."
+    if not _HAS_FFMPEG:
+        raise RuntimeError("Cannot find installation of real FFmpeg (which comes with ffprobe).")
 
     filename = os.fspath(filename)
 

--- a/skvideo/io/io.py
+++ b/skvideo/io/io.py
@@ -82,7 +82,8 @@ def vwrite(fname, videodata, inputdict=None, outputdict=None, backend='ffmpeg', 
 
     if backend == "ffmpeg":
         # check if FFMPEG exists in the path
-        assert _HAS_FFMPEG, "Cannot find installation of real FFmpeg (which comes with ffprobe)."
+        if not _HAS_FFMPEG:
+            raise RuntimeError("Cannot find installation of real FFmpeg (which comes with ffprobe).")
 
         writer = FFmpegWriter(fname, inputdict=inputdict, outputdict=outputdict,
                               audiosrc=audiosrc, verbosity=verbosity)
@@ -93,7 +94,8 @@ def vwrite(fname, videodata, inputdict=None, outputdict=None, backend='ffmpeg', 
         if audiosrc is not None:
             raise NotImplementedError("audiosrc passthrough is only supported with backend='ffmpeg'")
         # check if FFMPEG exists in the path
-        assert _HAS_AVCONV, "Cannot find installation of libav."
+        if not _HAS_AVCONV:
+            raise RuntimeError("Cannot find installation of libav.")
         writer = LibAVWriter(fname, inputdict=inputdict, outputdict=outputdict, verbosity=verbosity)
         for t in range(T):
             writer.writeFrame(videodata[t])
@@ -167,7 +169,8 @@ def vread(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=None,
 
     if backend == "ffmpeg":
         # check if FFMPEG exists in the path
-        assert _HAS_FFMPEG, "Cannot find installation of real FFmpeg (which comes with ffprobe)."
+        if not _HAS_FFMPEG:
+            raise RuntimeError("Cannot find installation of real FFmpeg (which comes with ffprobe).")
 
         if ((height != 0) and (width != 0)):
             inputdict['-s'] = str(width) + 'x' + str(height)
@@ -203,7 +206,8 @@ def vread(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=None,
         return videodata
     elif backend == "libav":
         # check if FFMPEG exists in the path
-        assert _HAS_AVCONV, "Cannot find installation of libav."
+        if not _HAS_AVCONV:
+            raise RuntimeError("Cannot find installation of libav.")
 
         if ((height != 0) and (width != 0)):
             inputdict['-s'] = str(width) + 'x' + str(height)
@@ -297,7 +301,8 @@ def vreader(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=Non
 
     if backend == "ffmpeg":
         # check if FFMPEG exists in the path
-        assert _HAS_FFMPEG, "Cannot find installation of ffmpeg."
+        if not _HAS_FFMPEG:
+            raise RuntimeError("Cannot find installation of ffmpeg.")
 
         if ((height != 0) and (width != 0)):
             inputdict['-s'] = str(width) + 'x' + str(height)
@@ -320,7 +325,8 @@ def vreader(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=Non
 
     elif backend == "libav":
         # check if FFMPEG exists in the path
-        assert _HAS_AVCONV, "Cannot find installation of libav."
+        if not _HAS_AVCONV:
+            raise RuntimeError("Cannot find installation of libav.")
 
         if ((height != 0) and (width != 0)):
             inputdict['-s'] = str(width) + 'x' + str(height)

--- a/skvideo/io/mprobe.py
+++ b/skvideo/io/mprobe.py
@@ -26,7 +26,8 @@ def mprobe(filename):
        about the passed-in source video.
 
     """
-    assert _HAS_MEDIAINFO, "`mediainfo` not found in path. Is it installed?"
+    if not _HAS_MEDIAINFO:
+        raise RuntimeError("`mediainfo` not found in path. Is it installed?")
 
     try:
         # '-f' gets full output, and --Output=XML is xml formatted output
@@ -37,26 +38,32 @@ def mprobe(filename):
 
         d = xmltodictparser(xml)
 
-        assert "Mediainfo" in d
+        if "Mediainfo" not in d:
+            raise ValueError("mediainfo XML missing the 'Mediainfo' root element")
         d = d["Mediainfo"]
 
-        assert "File" in d
+        if "File" not in d:
+            raise ValueError("mediainfo XML missing the 'File' element")
         d = d["File"]
 
-        assert "track" in d
+        if "track" not in d:
+            raise ValueError("mediainfo XML missing 'track' elements")
         unorderedtracks = d["track"]
 
         # tracksbytype normalizes the input by key
         tracksbytype = {}
         if type(unorderedtracks) is list:
             for d in unorderedtracks:
-                assert "@type" in d
+                if "@type" not in d:
+                    raise ValueError("mediainfo track missing '@type'")
                 # can't have more than 1 key. If this case arises
                 # an issue should be made in the tracker for a fix.
-                assert d["@type"] not in tracksbytype 
+                if d["@type"] in tracksbytype:
+                    raise ValueError("mediainfo returned duplicate track @type %r" % d["@type"])
                 tracksbytype[d["@type"]] = d
         else: # not list
-            assert "@type" in unorderedtracks
+            if "@type" not in unorderedtracks:
+                raise ValueError("mediainfo track missing '@type'")
             tracksbytype[unorderedtracks["@type"]] = unorderedtracks
 
         return tracksbytype

--- a/skvideo/measure/ssim.py
+++ b/skvideo/measure/ssim.py
@@ -214,6 +214,11 @@ def ssim_full(referenceVideoData, distortedVideoData, K_1 = 0.01, K_2 = 0.03, bi
     if not (C == 1):
         raise ValueError("ssim called with videos containing %d channels. Please supply only the luminance channel" % (C,))
 
+    # Same 11x11 minimum as ssim(): smaller frames produce empty (M-10, N-10)
+    # maps and silently return NaN.
+    if M < 11 or N < 11:
+        raise ValueError("ssim_full requires frames of at least 11x11 pixels; got %dx%d." % (M, N))
+
     factor = int(np.max((1, np.round(np.min((M, N))/256.0))))
 
     if scaleFix:

--- a/skvideo/measure/ssim.py
+++ b/skvideo/measure/ssim.py
@@ -129,6 +129,12 @@ def ssim(referenceVideoData, distortedVideoData, K_1 = 0.01, K_2 = 0.03, bitdept
     if not (C == 1):
         raise ValueError("ssim called with videos containing %d channels. Please supply only the luminance channel" % (C,))
 
+    # The SSIM map is computed with an 11-tap window and then trimmed 5px on
+    # each side; frames smaller than 11x11 trim to an empty map and silently
+    # produce NaN. Reject up front with a clear error instead.
+    if M < 11 or N < 11:
+        raise ValueError("ssim requires frames of at least 11x11 pixels; got %dx%d." % (M, N))
+
     ssim_scores = np.zeros(T, dtype=np.float32)
 
     for t in range(T):

--- a/skvideo/tests/test_error_handling.py
+++ b/skvideo/tests/test_error_handling.py
@@ -217,3 +217,61 @@ def test_ssim_rejects_too_small_frames():
         M.ssim(tiny, tiny)
     with pytest.raises(ValueError):
         M.ssim_full(tiny, tiny)
+
+
+def test_empty_bytesio_raises_clear_runtimeerror_not_calledprocesserror():
+    """An empty/undecodable memory source with -s/-pix_fmt falls through to
+    the count-frames probe, which previously leaked a raw
+    subprocess.CalledProcessError. It must raise a clear RuntimeError that
+    tells the user the input is unreadable and how to declare frame count.
+    CalledProcessError is NOT a RuntimeError, so this assertion fails if the
+    raw error leaks."""
+    import io as _io
+    import warnings
+    import skvideo.io
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        with pytest.raises(RuntimeError):
+            skvideo.io.vread(
+                _io.BytesIO(b""),
+                inputdict={"-s": "16x16", "-pix_fmt": "rgb24"},
+            )
+
+
+def test_empty_bytesio_error_path_leaks_no_tempfile():
+    """The constructor spools the memory source to a temp file before the
+    probe fails; the failure cleanup must still unlink it."""
+    import glob
+    import io as _io
+    import os
+    import tempfile
+    import warnings
+    import skvideo.io
+    pattern = os.path.join(tempfile.gettempdir(), "skvideo_in_*")
+    before = set(glob.glob(pattern))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        for _ in range(3):
+            try:
+                skvideo.io.vread(
+                    _io.BytesIO(b""),
+                    inputdict={"-s": "16x16", "-pix_fmt": "rgb24"},
+                )
+            except RuntimeError:
+                pass
+    assert set(glob.glob(pattern)) == before
+
+
+def test_start_frame_past_eof_emits_no_resourcewarning():
+    """Seeking past EOF makes ffmpeg exit before close() runs. close() must
+    still close the pipe file objects (it previously skipped them when the
+    process had already exited, leaking a ResourceWarning)."""
+    import warnings
+    import skvideo.datasets
+    import skvideo.io
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ResourceWarning)
+        v = skvideo.io.vread(
+            skvideo.datasets.bigbuckbunny(), start_frame=99999, num_frames=2
+        )
+    assert v.shape[0] == 0

--- a/skvideo/tests/test_error_handling.py
+++ b/skvideo/tests/test_error_handling.py
@@ -209,9 +209,11 @@ def test_backend_missing_raises_runtimeerror_under_O():
 
 
 def test_ssim_rejects_too_small_frames():
-    """ssim on frames smaller than the 11x11 window silently returned NaN
-    (the map trims to empty); it must raise a clear ValueError instead."""
+    """ssim / ssim_full on frames smaller than the 11x11 window silently
+    returned NaN (the map trims to empty); both must raise ValueError."""
     import skvideo.measure as M
     tiny = np.zeros((2, 8, 8, 1), dtype=np.uint8)
     with pytest.raises(ValueError):
         M.ssim(tiny, tiny)
+    with pytest.raises(ValueError):
+        M.ssim_full(tiny, tiny)

--- a/skvideo/tests/test_error_handling.py
+++ b/skvideo/tests/test_error_handling.py
@@ -206,3 +206,12 @@ def test_backend_missing_raises_runtimeerror_under_O():
     )
     out = subprocess.run([sys.executable, "-O", "-c", code], capture_output=True, text=True)
     assert "RUNTIMEERROR" in out.stdout, (out.stdout, out.stderr[-200:])
+
+
+def test_ssim_rejects_too_small_frames():
+    """ssim on frames smaller than the 11x11 window silently returned NaN
+    (the map trims to empty); it must raise a clear ValueError instead."""
+    import skvideo.measure as M
+    tiny = np.zeros((2, 8, 8, 1), dtype=np.uint8)
+    with pytest.raises(ValueError):
+        M.ssim(tiny, tiny)

--- a/skvideo/tests/test_error_handling.py
+++ b/skvideo/tests/test_error_handling.py
@@ -187,3 +187,22 @@ def test_setffmpegpath_bad_path_clears_codec_caches():
     finally:
         skvideo.setFFmpegPath(orig)  # restore for the rest of the session
     assert skvideo._HAS_FFMPEG == 1
+
+
+def test_backend_missing_raises_runtimeerror_under_O():
+    """Backend-availability checks must be real exceptions, not asserts, so a
+    missing ffmpeg is reported even under `python -O` (where asserts vanish)."""
+    import subprocess
+    import sys
+    code = (
+        "import importlib\n"
+        "m = importlib.import_module('skvideo.io.ffprobe')\n"
+        "m._HAS_FFMPEG = 0\n"   # simulate ffmpeg not installed
+        "try:\n"
+        "    m.ffprobe('whatever.mp4')\n"
+        "    print('NORAISE')\n"
+        "except RuntimeError:\n"
+        "    print('RUNTIMEERROR')\n"
+    )
+    out = subprocess.run([sys.executable, "-O", "-c", code], capture_output=True, text=True)
+    assert "RUNTIMEERROR" in out.stdout, (out.stdout, out.stderr[-200:])

--- a/skvideo/utils/image.py
+++ b/skvideo/utils/image.py
@@ -17,12 +17,14 @@ def imresize(image, factor, interp="nearest", mode=None):
         "bicubic": PIL.Image.BICUBIC,
         "bilinear": PIL.Image.BILINEAR
     }
-    assert(interp in interp_methods)
+    if interp not in interp_methods:
+        raise ValueError("interp must be one of %s; got %r." % (sorted(interp_methods), interp))
 
     if type(factor) != tuple:
         new_shape = (int(factor * image.shape[0]), int(factor * image.shape[1]))
     else:
-        assert(len(factor) == 2)
+        if len(factor) != 2:
+            raise ValueError("factor tuple must have length 2; got %d." % len(factor))
         new_shape = factor
 
     h, w = new_shape

--- a/skvideo/utils/mscn.py
+++ b/skvideo/utils/mscn.py
@@ -20,7 +20,8 @@ def gen_gauss_window(lw, sigma):
 def compute_image_mscn_transform(image, C=1, avg_window=None, extend_mode='constant'):
     if avg_window is None:
       avg_window = gen_gauss_window(3, 7.0/6.0)
-    assert len(np.shape(image)) == 2
+    if len(np.shape(image)) != 2:
+        raise ValueError("compute_image_mscn_transform expects a 2D image; got shape %s." % (np.shape(image),))
     h, w = np.shape(image)
     mu_image = np.zeros((h, w), dtype=np.float32)
     var_image = np.zeros((h, w), dtype=np.float32)

--- a/skvideo/utils/stpyr.py
+++ b/skvideo/utils/stpyr.py
@@ -229,10 +229,10 @@ class Steerable:
     def normalize(self, coef, height, order):
         filtsize = (3, 3)
         norm_bands = []
-        for pyr_h in xrange(height-2):
+        for pyr_h in range(height-2):
             inner_norm_bands = []
             sublevel = coef[pyr_h+1]
-            for cband in xrange(order):
+            for cband in range(order):
                 child = coef[0]
                 parent = []
                 w, h = np.shape(sublevel[cband])


### PR DESCRIPTION
## Summary

Correctness-completion pass continuing the v1.1.14 hardening. No new features; makes remaining failures loud and clean.

- **Finish the assert→exception sweep**: all remaining user-facing `assert` validation now raises real exceptions (survives `python -O`). Backend-availability checks (FFmpeg/libav/mediainfo + libav version) → `RuntimeError`; `mprobe` XML-parse guards and `utils.mscn`/`utils.image` input checks → `ValueError`. Only the two internal `self._proc is not None` invariants remain as asserts.
- **ssim** raises `ValueError` for frames smaller than its 11×11 window instead of silently returning `NaN`.
- Ported the last Python-2 `xrange` (`utils/stpyr.py`) → `range`.
- Documented that metrics assume finite input (NaN/inf is caller responsibility; not enforced).

## Test plan

- Full suite: 169 passed / 16 skipped / 0 failed (Python 3.12, ffmpeg 8.1).
- New regression tests: backend-missing raises `RuntimeError` under `python -O`; ssim rejects sub-window frames.
- CI matrix (Python 3.10–3.13 × Linux/macOS) on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)