### PR TITLE
io: skip exact frame-count probe in vreader() for unknown-count inputs

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -50,7 +50,13 @@ This should produce output like
 Loading videos using vread is sooooo slow!
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You may not have supplied `num_frames`. The autodetection process sometimes requires two passes on an input video (depending on the type of video), which can make a huge difference for a large video corpus. By supplying `num_frames`, your code may speed up tremendously.
+You may not have supplied `num_frames`. For full-array reads with
+``vread``, autodetection sometimes requires two passes on an input video
+(depending on the type of video), which can make a huge difference for a
+large video corpus. By supplying `num_frames`, your code may speed up
+tremendously. If you only need to iterate frames, ``vreader`` avoids the
+extra exact frame-count scan when the container metadata does not report a
+frame count; it streams until EOF instead.
 
 How do I report a bug with scikit-video?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -111,7 +111,9 @@ class VideoReaderAbstract(object):
     DEFAULT_INPUT_PIX_FMT = "yuvj444p"
     OUTPUT_METHOD = None  # "rawvideo"
 
-    def __init__(self, filename, inputdict=None, outputdict=None, verbosity=0, start_frame=0):
+    def __init__(
+            self, filename, inputdict=None, outputdict=None, verbosity=0,
+            start_frame=0, scan_frames=True):
         """Initializes FFmpeg in reading mode with the given parameters
 
         During initialization, additional parameters about the video file
@@ -148,6 +150,12 @@ class VideoReaderAbstract(object):
             dropped frames back to a constant rate, and on FFmpeg 5.1+ is
             equivalent to ``-fps_mode passthrough``). That is slower
             because it decodes from the start of the file.
+
+        scan_frames : bool
+            If true, scan the input with ffprobe/avprobe when metadata does
+            not expose a frame count. This preserves the historical exact
+            ``getShape()[0]`` behavior but can be very slow on large videos.
+            Generator-style readers can disable it and read until EOF.
 
         Returns
         -------
@@ -198,7 +206,9 @@ class VideoReaderAbstract(object):
         # reference to the half-constructed reader, so close() is
         # unreachable and the temp file leaks.
         try:
-            self._finish_init(filename, inputdict, outputdict, verbosity, start_frame)
+            self._finish_init(
+                filename, inputdict, outputdict, verbosity, start_frame,
+                scan_frames)
         except Exception:
             if self._temp_input_path is not None:
                 try:
@@ -208,7 +218,7 @@ class VideoReaderAbstract(object):
                 self._temp_input_path = None
             raise
 
-    def _finish_init(self, filename, inputdict, outputdict, verbosity, start_frame):
+    def _finish_init(self, filename, inputdict, outputdict, verbosity, start_frame, scan_frames):
         """The rest of __init__, wrapped so spool failure cleanup can apply.
 
         Extracted purely for the try/except boundary; semantics are
@@ -358,11 +368,19 @@ class VideoReaderAbstract(object):
             # webcam (or live URL) can stream frames endlessly, lets use the
             # special default value of 0 to indicate that
             self.inputframenum = 0
-        else:
+        elif scan_frames:
             self.inputframenum = self._probCountFrames()
             if verbosity != 0:
                 warnings.warn(
                     "Cannot determine frame count. Scanning input file, this is slow when repeated many times. Need `-vframes` in inputdict. Consult documentation on I/O.",
+                    UserWarning)
+        else:
+            self.inputframenum = 0
+            if verbosity != 0:
+                warnings.warn(
+                    "Cannot determine frame count from metadata. Reading until EOF; "
+                    "pass `num_frames`/`-vframes` to declare a limit, or construct "
+                    "the reader with scan_frames=True for an exact getShape()[0].",
                     UserWarning)
 
         # Adjust the expected frame count for start_frame seek so getShape()

--- a/skvideo/io/io.py
+++ b/skvideo/io/io.py
@@ -253,6 +253,8 @@ def vreader(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=Non
     num_frames : int
         Only read the first `num_frames` number of frames from video.
         Setting `num_frames` to small numbers can significantly speed up video loading times.
+        If omitted and the container does not expose a frame count, the
+        generator reads until EOF instead of scanning the whole file up front.
 
     as_grey : bool
         If true, only load the luminance channel of the input video.
@@ -313,7 +315,9 @@ def vreader(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=Non
         if as_grey:
             outputdict['-pix_fmt'] = 'gray'
 
-        reader = FFmpegReader(fname, inputdict=inputdict, outputdict=outputdict, verbosity=verbosity, start_frame=start_frame)
+        reader = FFmpegReader(
+            fname, inputdict=inputdict, outputdict=outputdict,
+            verbosity=verbosity, start_frame=start_frame, scan_frames=False)
         try:
             for frame in reader.nextFrame():
                 if as_grey:
@@ -334,7 +338,9 @@ def vreader(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=Non
         if num_frames != 0:
             outputdict['-vframes'] = str(num_frames)
 
-        reader = LibAVReader(fname, inputdict=inputdict, outputdict=outputdict, verbosity=verbosity)
+        reader = LibAVReader(
+            fname, inputdict=inputdict, outputdict=outputdict,
+            verbosity=verbosity, scan_frames=False)
         try:
             for frame in reader.nextFrame():
                 yield frame

--- a/skvideo/tests/test_ffmpeg.py
+++ b/skvideo/tests/test_ffmpeg.py
@@ -132,6 +132,83 @@ def test_FFmpegReader_fps():
 
 
 @unittest.skipIf(not skvideo._HAS_FFMPEG, "FFmpeg required for this test.")
+def test_FFmpegReader_can_skip_exact_frame_count_probe(monkeypatch, tmp_path):
+    filename = tmp_path / "unknown_count.mp4"
+    filename.write_bytes(b"probe path is mocked")
+    count_probe_calls = []
+
+    def fake_probe(self):
+        return {
+            "video": {
+                "@r_frame_rate": "30/1",
+                "@width": "16",
+                "@height": "8",
+                "@pix_fmt": "rgb24",
+            }
+        }
+
+    def fail_count_probe(self):
+        count_probe_calls.append(self._filename)
+        raise AssertionError("frame count probe should not run")
+
+    def fake_create_process(self, inputdict, outputdict, verbosity):
+        self._proc = None
+        self._cmd = "mock ffmpeg"
+
+    monkeypatch.setattr(skvideo.io.FFmpegReader, "_probe", fake_probe)
+    monkeypatch.setattr(skvideo.io.FFmpegReader, "_probCountFrames", fail_count_probe)
+    monkeypatch.setattr(skvideo.io.FFmpegReader, "_createProcess", fake_create_process)
+    monkeypatch.setattr(skvideo.io.FFmpegReader, "_getSupportedDecoders", lambda self: NotImplemented)
+
+    reader = skvideo.io.FFmpegReader(str(filename), scan_frames=False)
+    try:
+        assert reader.getShape() == (0, 8, 16, 3)
+        assert count_probe_calls == []
+    finally:
+        reader.close()
+
+
+@unittest.skipIf(not skvideo._HAS_FFMPEG, "FFmpeg required for this test.")
+def test_vreader_skips_exact_frame_count_probe_for_unknown_count(monkeypatch, tmp_path):
+    filename = tmp_path / "unknown_count.mp4"
+    filename.write_bytes(b"probe path is mocked")
+    count_probe_calls = []
+
+    def fake_probe(self):
+        return {
+            "video": {
+                "@r_frame_rate": "30/1",
+                "@width": "16",
+                "@height": "8",
+                "@pix_fmt": "rgb24",
+            }
+        }
+
+    def fail_count_probe(self):
+        count_probe_calls.append(self._filename)
+        raise AssertionError("frame count probe should not run")
+
+    def fake_create_process(self, inputdict, outputdict, verbosity):
+        self._proc = None
+        self._cmd = "mock ffmpeg"
+
+    def fake_next_frame(self):
+        yield np.zeros((8, 16, 3), dtype=np.uint8)
+
+    monkeypatch.setattr(skvideo.io.FFmpegReader, "_probe", fake_probe)
+    monkeypatch.setattr(skvideo.io.FFmpegReader, "_probCountFrames", fail_count_probe)
+    monkeypatch.setattr(skvideo.io.FFmpegReader, "_createProcess", fake_create_process)
+    monkeypatch.setattr(skvideo.io.FFmpegReader, "_getSupportedDecoders", lambda self: NotImplemented)
+    monkeypatch.setattr(skvideo.io.FFmpegReader, "nextFrame", fake_next_frame)
+
+    frames = list(skvideo.io.vreader(str(filename)))
+
+    assert len(frames) == 1
+    assert frames[0].shape == (8, 16, 3)
+    assert count_probe_calls == []
+
+
+@unittest.skipIf(not skvideo._HAS_FFMPEG, "FFmpeg required for this test.")
 def test_FFmpegWriter():
     # generate random data for 5 frames
     outputfile = sys._getframe().f_code.co_name + ".mp4"


### PR DESCRIPTION
Fixes #193.

## Symptom
`skvideo.io.vreader()` on a file whose container metadata lacks `nb_frames`
(common for VFR, MKV/WebM, fragmented MP4) stalls for minutes before the first
frame — ffprobe runs `-count_frames`, which fully decodes the video. Surfaced
via Practical-RIFE, which calls `vreader(args.video)`.

## Root cause
`VideoReaderAbstract` resolves `inputframenum` through a tiered chain; with no
`nb_frames` / `-vframes` / `-r` hint it falls back to `_probCountFrames()` ->
`ffprobe -count_frames`. For `vreader()` that count is wasted: it is a generator
whose consumers read to EOF and never read `getShape()[0]`.

## Fix
Add `scan_frames` (default `True`) to the reader constructors. When `False`, an
unknown frame count resolves to `0`, which `nextFrame()` already treats as
"stream until EOF" (the existing webcam path). `vreader()` now constructs its
readers with `scan_frames=False`.

`vread()` is intentionally left unchanged: it preallocates `np.empty((T, ...))`
from `getShape()` and still needs the exact count. So this fixes the generator
path, not `-count_frames` globally.

Regression tests assert the count probe is not invoked; the FAQ documents the
`vread` vs `vreader` distinction.

## Workaround for released versions
```python
videogen = skvideo.io.vreader(args.video, num_frames=int(tot_frame))
```
