### PR TITLE
Deprecations: libav backend, mprobe, extension allowlist; no CWD/relative-PATH binary resolution

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,33 @@
+Unreleased
+----------
+
+Deprecations (removal planned for the release after next)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **The libav/avconv backend is deprecated** (``LibAVReader``,
+  ``LibAVWriter``, ``backend='libav'``, ``setLibAVPath``). libav is
+  unmaintained upstream and the backend has never been covered by CI;
+  FFmpeg is the validated backend.
+- **``mprobe``/mediainfo support is deprecated.** Nothing inside
+  scikit-video consumes it; use ``skvideo.io.ffprobe``.
+- **The hardcoded container-extension allowlist is deprecated** and no
+  longer rejects: an extension missing from the (2016-era frozen) list
+  now warns and defers to ffmpeg, which detects containers from content.
+  Formats newer than the snapshot (e.g. ``.avif``) work; genuinely
+  unreadable inputs fail loudly through the 1.2.1 error-reporting paths.
+  **Behavior change:** writing to an unknown extension raises
+  ``RuntimeError`` with ffmpeg's diagnostics at write time instead of
+  ``ValueError`` at construction.
+
+Fixed
+~~~~~
+
+- Binaries (ffprobe/ffmpeg/avconv/mediainfo) are no longer resolved from
+  the current working directory -- only from PATH. A stray or malicious
+  file named ``ffprobe`` in the CWD could previously be executed by
+  ``import skvideo``.
+
+
 1.2.1 (2026-07-02)
 ------------------
 Maintenance release: NumPy 2.5 compatibility, reader error-reporting,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,10 +22,13 @@ Deprecations (removal planned for the release after next)
 Fixed
 ~~~~~
 
-- Binaries (ffprobe/ffmpeg/avconv/mediainfo) are no longer resolved from
-  the current working directory -- only from PATH. A stray or malicious
-  file named ``ffprobe`` in the CWD could previously be executed by
-  ``import skvideo``.
+- Binaries (ffprobe/ffmpeg/avconv/mediainfo) are now resolved only from
+  **absolute** PATH entries -- never from the current working directory.
+  A stray or malicious file named ``ffprobe`` in the CWD could
+  previously be executed by ``import skvideo``, both via the explicit
+  CWD search entry and via empty PATH elements (leading/trailing/double
+  separators, which POSIX treats as the CWD); relative PATH entries are
+  excluded for the same reason.
 
 
 1.2.1 (2026-07-02)

--- a/README.rst
+++ b/README.rst
@@ -38,8 +38,7 @@ Dependencies and Installation
 Requirements:
 
 - FFmpeg >= 2.8 on the system PATH (primary tested backend). The libav/avconv
-  backend is retained in the codebase for compatibility but is not validated
-  by the test suite.
+  backend is **deprecated** and will be removed in a future release.
 - Python >= 3.10
 - numpy >= 1.22
 - scipy >= 1.9

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Requirements:
 - numpy >= 1.22
 - scipy >= 1.9
 - Pillow >= 9.0
-- mediainfo (optional)
+- mediainfo (optional; **deprecated**, will be removed in a future release)
 
 Installation from PyPI::
 
@@ -106,7 +106,7 @@ TODO/Roadmap
 ------------
 - Spatial-Temporal filtering helper functions
 - Speedup routines (using cython and/or opencl)
-- More ffmpeg/avconv interfacing
+- More ffmpeg interfacing
 - Add additional algorithms and maintain more comprehensive benchmarks
 
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -17,10 +17,13 @@ against a consistent and peer-reviewed set of tools.
 Finally, scikit-video provides helpful utilities, like scene-boundary detectors and block-motion estimators commonly
 used in video processing algorithms.
 
-How do I tell scikit-video to use different FFmpeg/LibAV installs?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+How do I tell scikit-video to use a different FFmpeg install?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can use the function :mod:`skvideo.setFFmpegPath` or :mod:`skvideo.setLibAVPath` in the core :mod:`skvideo` API.
+You can use the function :mod:`skvideo.setFFmpegPath` in the core
+:mod:`skvideo` API. (:mod:`skvideo.setLibAVPath` still exists but the
+libav/avconv backend is deprecated and will be removed in a future
+release.)
 
 I installed scikit-video, but the API I installed does not match the website! How do I fix this?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/modules/io.rst
+++ b/doc/modules/io.rst
@@ -24,6 +24,10 @@ Classes
    LibAVWriter
    LibAVReader
 
+.. deprecated:: 1.3.0
+   ``LibAVWriter`` and ``LibAVReader`` (the libav/avconv backend) are
+   deprecated and will be removed in a future release. Use the FFmpeg
+   backend.
 
 Functions
 ---------
@@ -37,3 +41,7 @@ Functions
    mprobe
    ffprobe
    avprobe
+
+.. deprecated:: 1.3.0
+   ``mprobe`` (mediainfo) and ``avprobe`` (libav) are deprecated and
+   will be removed in a future release. Use :func:`skvideo.io.ffprobe`.

--- a/skvideo/__init__.py
+++ b/skvideo/__init__.py
@@ -483,6 +483,10 @@ def setLibAVPath(path):
         none
 
     """
+    warnings.warn(
+        "The libav/avconv backend is deprecated and will be removed in a "
+        "future release. Use the ffmpeg backend (setFFmpegPath) instead.",
+        DeprecationWarning, stacklevel=2)
     global _AVCONV_PATH
     global _HAS_AVCONV
     _AVCONV_PATH = path

--- a/skvideo/io/abstract.py
+++ b/skvideo/io/abstract.py
@@ -410,9 +410,17 @@ class VideoReaderAbstract(object):
         else:
             decoders = self._getSupportedDecoders()
             if decoders != NotImplemented:
-                # check that the extension makes sense
+                # The extension allowlist is a frozen snapshot of an old
+                # ffmpeg's formats; ffmpeg detects containers from content,
+                # not extension, and URL/BytesIO inputs never went through
+                # this check. Defer to ffmpeg (whose failure now surfaces
+                # loudly) instead of rejecting.
                 if str.encode(self.extension).lower() not in decoders:
-                    raise ValueError("Unknown decoder extension: " + self.extension.lower())
+                    warnings.warn(
+                        "extension %r is not in skvideo's known-container "
+                        "list; passing the file to ffmpeg anyway. (This "
+                        "hardcoded allowlist is deprecated and will be "
+                        "removed.)" % self.extension.lower(), UserWarning)
 
         if '-f' not in outputdict:
             outputdict['-f'] = self.OUTPUT_METHOD
@@ -716,11 +724,18 @@ class VideoWriterAbstract(object):
         if self._dest_kind == "file":
             filename = os.path.abspath(os.fspath(filename))
             _, self.extension = os.path.splitext(filename)
-            # check that the extension makes sense
+            # See the reader-side note: the allowlist is a frozen snapshot.
+            # For writing, ffmpeg infers the muxer from the extension; if it
+            # can't, its own error surfaces at write/close time (issue #111).
             encoders = self._getSupportedEncoders()
             if encoders != NotImplemented:
                 if str.encode(self.extension).lower() not in encoders:
-                    raise ValueError("Unknown encoder extension: " + self.extension.lower())
+                    warnings.warn(
+                        "extension %r is not in skvideo's known-container "
+                        "list; passing it to ffmpeg anyway (set '-f' in "
+                        "outputdict to name the muxer explicitly). (This "
+                        "hardcoded allowlist is deprecated and will be "
+                        "removed.)" % self.extension.lower(), UserWarning)
 
             self._filename = filename
             basepath, _ = os.path.split(filename)

--- a/skvideo/io/avconv.py
+++ b/skvideo/io/avconv.py
@@ -8,6 +8,7 @@ a wide range of video formats.
 # distributed under the terms of the BSD License (included in release).
 
 import subprocess as sp
+import warnings
 
 import numpy as np
 
@@ -35,6 +36,11 @@ class LibAVReader(VideoReaderAbstract):
     OUTPUT_METHOD = "rawvideo"
 
     def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "The libav/avconv backend is deprecated and will be removed in "
+            "a future release (libav is unmaintained upstream and this "
+            "backend is not covered by scikit-video's CI). Use the ffmpeg "
+            "backend instead.", DeprecationWarning, stacklevel=2)
         if not skvideo._HAS_AVCONV:
             raise RuntimeError("Cannot find installation of libav (which comes with avprobe).")
         super(LibAVReader,self).__init__(*args, **kwargs)
@@ -90,6 +96,11 @@ class LibAVWriter(VideoWriterAbstract):
     """
 
     def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "The libav/avconv backend is deprecated and will be removed in "
+            "a future release (libav is unmaintained upstream and this "
+            "backend is not covered by scikit-video's CI). Use the ffmpeg "
+            "backend instead.", DeprecationWarning, stacklevel=2)
         if not skvideo._HAS_AVCONV:
             raise RuntimeError("Cannot find installation of libav (which comes with avprobe).")
         super(LibAVWriter,self).__init__(*args, **kwargs)

--- a/skvideo/io/io.py
+++ b/skvideo/io/io.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 import numpy as np
 
@@ -21,6 +22,14 @@ def _normalize_source(fname):
     if _classify_source(fname) == "memory":
         return fname
     return os.fspath(fname)
+
+
+def _warn_libav_deprecated():
+    warnings.warn(
+        "The libav/avconv backend is deprecated and will be removed in a "
+        "future release (libav is unmaintained upstream and this backend "
+        "is not covered by scikit-video's CI). Use the ffmpeg backend "
+        "instead.", DeprecationWarning, stacklevel=3)
 
 
 def vwrite(fname, videodata, inputdict=None, outputdict=None, backend='ffmpeg', verbosity=0, audiosrc=None):
@@ -90,6 +99,7 @@ def vwrite(fname, videodata, inputdict=None, outputdict=None, backend='ffmpeg', 
             writer.writeFrame(videodata[t])
         writer.close()
     elif backend == "libav":
+        _warn_libav_deprecated()
         if audiosrc is not None:
             raise NotImplementedError("audiosrc passthrough is only supported with backend='ffmpeg'")
         # check if FFMPEG exists in the path
@@ -214,6 +224,7 @@ def vread(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=None,
 
         return videodata
     elif backend == "libav":
+        _warn_libav_deprecated()
         # check if FFMPEG exists in the path
         if not skvideo._HAS_AVCONV:
             raise RuntimeError("Cannot find installation of libav.")
@@ -333,6 +344,7 @@ def vreader(fname, height=0, width=0, num_frames=0, as_grey=False, inputdict=Non
             reader.close()
 
     elif backend == "libav":
+        _warn_libav_deprecated()
         # check if FFMPEG exists in the path
         if not skvideo._HAS_AVCONV:
             raise RuntimeError("Cannot find installation of libav.")

--- a/skvideo/io/mprobe.py
+++ b/skvideo/io/mprobe.py
@@ -26,6 +26,10 @@ def mprobe(filename):
        about the passed-in source video.
 
     """
+    warnings.warn(
+        "mprobe/mediainfo support is deprecated and will be removed in a "
+        "future release; nothing inside scikit-video consumes it. Use "
+        "skvideo.io.ffprobe instead.", DeprecationWarning, stacklevel=2)
     if not _HAS_MEDIAINFO:
         raise RuntimeError("`mediainfo` not found in path. Is it installed?")
 

--- a/skvideo/tests/test_IOfail.py
+++ b/skvideo/tests/test_IOfail.py
@@ -20,11 +20,14 @@ def test_failedwrite():
         skvideo.io.vwrite("garbage/garbage.mp4", outputdata)
 
 
-def test_failedextension():
-    # 'garbage' extension is not a known encoder extension -> ValueError
-    # (previously a bare assert, stripped under `python -O`).
+def test_failedextension(tmp_path):
+    # An unknown extension no longer trips the (deprecated) hardcoded
+    # allowlist ValueError; it warns and defers to ffmpeg, which cannot
+    # infer a muxer for '.garbage' and fails loudly at write time with
+    # its own diagnostics (issue #111 machinery).
     np.random.seed(0)
     outputdata = np.random.random(size=(5, 480, 640, 3)) * 255
     outputdata = outputdata.astype(np.uint8)
-    with pytest.raises(ValueError):
-        skvideo.io.vwrite("garbage.garbage", outputdata)
+    with pytest.warns(UserWarning, match="[Ee]xtension"):
+        with pytest.raises((RuntimeError, OSError)):
+            skvideo.io.vwrite(str(tmp_path / "garbage.garbage"), outputdata)

--- a/skvideo/tests/test_deprecations.py
+++ b/skvideo/tests/test_deprecations.py
@@ -1,0 +1,94 @@
+"""1.3.0-line deprecations and behavior fixes:
+
+- libav/avconv backend and mediainfo/mprobe are deprecated (dead upstream,
+  never CI-tested) -- one release of DeprecationWarning before removal.
+- The hardcoded container-extension allowlist (a frozen snapshot of a
+  2016-era ffmpeg's formats) now warns and defers to ffmpeg instead of
+  rejecting extensions ffmpeg may well support (URL and BytesIO inputs
+  always bypassed it anyway).
+- Binaries are no longer resolved from the current working directory.
+"""
+import os
+import shutil
+
+import numpy as np
+import pytest
+
+import skvideo
+import skvideo.datasets
+import skvideo.io
+import skvideo.utils
+
+
+# --- libav / mediainfo deprecation -------------------------------------
+
+def test_libav_reader_warns_deprecated():
+    with pytest.warns(DeprecationWarning, match="libav"):
+        try:
+            skvideo.io.LibAVReader(skvideo.datasets.bigbuckbunny())
+        except RuntimeError:
+            pass  # avconv not installed; the warning must fire first
+
+
+def test_libav_writer_warns_deprecated(tmp_path):
+    with pytest.warns(DeprecationWarning, match="libav"):
+        try:
+            skvideo.io.LibAVWriter(str(tmp_path / "out.mp4"))
+        except RuntimeError:
+            pass
+
+
+def test_setLibAVPath_warns_deprecated():
+    import warnings
+    with pytest.warns(DeprecationWarning, match="libav"):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            warnings.simplefilter("always", DeprecationWarning)
+            skvideo.setLibAVPath("/nonexistent")
+
+
+def test_mprobe_warns_deprecated():
+    with pytest.warns(DeprecationWarning, match="mediainfo"):
+        try:
+            skvideo.io.mprobe(skvideo.datasets.bigbuckbunny())
+        except RuntimeError:
+            pass  # mediainfo not installed; the warning must fire first
+
+
+# --- extension allowlist ------------------------------------------------
+
+@pytest.mark.skipif(not skvideo._HAS_FFMPEG, reason="FFmpeg required")
+def test_reader_unknown_extension_warns_and_reads(tmp_path):
+    """ffmpeg detects container format from content, not extension. An
+    extension missing from the frozen allowlist must warn and defer to
+    ffmpeg, not hard-fail -- .avif etc. postdate the snapshot."""
+    weird = str(tmp_path / "video.weirdext")
+    shutil.copy(skvideo.datasets.bigbuckbunny(), weird)
+    with pytest.warns(UserWarning, match="[Ee]xtension"):
+        videodata = skvideo.io.vread(weird, num_frames=2)
+    assert videodata.shape[0] == 2
+
+
+@pytest.mark.skipif(not skvideo._HAS_FFMPEG, reason="FFmpeg required")
+def test_writer_unknown_extension_warns_not_raises(tmp_path):
+    """Writer construction with an unknown extension warns instead of
+    raising; if ffmpeg really cannot infer a muxer, its own error now
+    surfaces loudly at write/close time."""
+    with pytest.warns(UserWarning, match="[Ee]xtension"):
+        writer = skvideo.io.FFmpegWriter(str(tmp_path / "out.weirdext"))
+    writer.close()
+
+
+# --- no CWD binary resolution -------------------------------------------
+
+def test_binaries_not_resolved_from_cwd(tmp_path, monkeypatch):
+    """`import skvideo` must not execute an ffprobe found in the current
+    working directory (hijack vector; no modern library resolves
+    executables from CWD)."""
+    fake = tmp_path / "fakebinary_skvideo_test"
+    fake.write_text("#!/bin/sh\necho fake\n")
+    fake.chmod(0o755)
+    monkeypatch.chdir(tmp_path)
+    matches = list(skvideo.utils.where("fakebinary_skvideo_test"))
+    assert matches == [], (
+        "binary resolved from CWD: %r" % matches)

--- a/skvideo/tests/test_deprecations.py
+++ b/skvideo/tests/test_deprecations.py
@@ -92,3 +92,43 @@ def test_binaries_not_resolved_from_cwd(tmp_path, monkeypatch):
     matches = list(skvideo.utils.where("fakebinary_skvideo_test"))
     assert matches == [], (
         "binary resolved from CWD: %r" % matches)
+
+
+def test_empty_path_elements_do_not_resolve_cwd(tmp_path, monkeypatch):
+    """POSIX treats empty PATH elements ('', leading/trailing/double
+    colons) as the CWD. Filtering only the explicit os.curdir prepend is
+    not enough -- binaries must resolve exclusively from absolute PATH
+    entries."""
+    fake = tmp_path / "fakebinary_skvideo_p1"
+    fake.write_text("#!/bin/sh\necho fake\n")
+    fake.chmod(0o755)
+    monkeypatch.chdir(tmp_path)
+    for path_value in ("", os.pathsep, os.pathsep + "/usr/bin",
+                       "/usr/bin" + os.pathsep, ".", "relative/dir"):
+        monkeypatch.setenv("PATH", path_value)
+        matches = list(skvideo.utils.where("fakebinary_skvideo_p1"))
+        assert matches == [], (
+            "binary resolved from CWD with PATH=%r: %r" % (path_value, matches))
+
+
+def test_high_level_backend_libav_warns_deprecated(tmp_path):
+    """The documented public API (vread/vreader/vwrite with
+    backend='libav') must warn even on systems without libav, where the
+    RuntimeError fires before LibAVReader/LibAVWriter would."""
+    with pytest.warns(DeprecationWarning, match="libav"):
+        try:
+            skvideo.io.vread(skvideo.datasets.bigbuckbunny(), backend="libav")
+        except RuntimeError:
+            pass
+    with pytest.warns(DeprecationWarning, match="libav"):
+        try:
+            next(skvideo.io.vreader(skvideo.datasets.bigbuckbunny(), backend="libav"))
+        except RuntimeError:
+            pass
+    with pytest.warns(DeprecationWarning, match="libav"):
+        try:
+            skvideo.io.vwrite(str(tmp_path / "o.mp4"),
+                              np.zeros((1, 4, 4, 3), dtype=np.uint8),
+                              backend="libav")
+        except RuntimeError:
+            pass

--- a/skvideo/utils/__init__.py
+++ b/skvideo/utils/__init__.py
@@ -265,10 +265,15 @@ def imapchain(*a, **kwa):
     return itertools.chain(*imap_results)
 
 def _gen_possible_matches(filename):
-    # PATH only -- never the current working directory. Resolving (and at
-    # import time, executing) an ffprobe found in CWD is a hijack vector
-    # and shadows the real install with any stray same-named file.
+    # Absolute PATH entries only -- never the current working directory.
+    # Resolving (and at import time, executing) an ffprobe found in CWD is
+    # a hijack vector and shadows the real install with any stray
+    # same-named file. Merely dropping the old explicit os.curdir prepend
+    # is not enough: POSIX treats EMPTY PATH elements (leading/trailing/
+    # double separators) as the CWD, and relative entries are
+    # CWD-dependent too, so both are excluded.
     path_parts =     os.environ.get("PATH", "").split(os.pathsep)
+    path_parts =     [p for p in path_parts if p and os.path.isabs(p)]
     possible_paths = map(lambda path_part: os.path.join(path_part, filename), path_parts)
 
     if platform.system() == "Windows":

--- a/skvideo/utils/__init__.py
+++ b/skvideo/utils/__init__.py
@@ -265,8 +265,10 @@ def imapchain(*a, **kwa):
     return itertools.chain(*imap_results)
 
 def _gen_possible_matches(filename):
+    # PATH only -- never the current working directory. Resolving (and at
+    # import time, executing) an ffprobe found in CWD is a hijack vector
+    # and shadows the real install with any stray same-named file.
     path_parts =     os.environ.get("PATH", "").split(os.pathsep)
-    path_parts =     itertools.chain((os.curdir,), path_parts)
     possible_paths = map(lambda path_part: os.path.join(path_part, filename), path_parts)
 
     if platform.system() == "Windows":


### PR DESCRIPTION
First half of the deprecate-then-remove plan for the structural cleanup (removal lands one release later).

## Deprecations (DeprecationWarning, removal planned for the release after next)
- **libav/avconv backend** — `LibAVReader`, `LibAVWriter`, `setLibAVPath`, and `backend='libav'` through `vread`/`vreader`/`vwrite` (the high-level branches warn *before* the availability check, so systems without libav still see the warning). libav is unmaintained upstream and this backend has never been CI-covered.
- **`mprobe`/mediainfo** — nothing inside scikit-video consumes it; its availability flag was broken (always 1) from 2017 until 1.2.1 without anyone noticing. Use `skvideo.io.ffprobe`.
- **Container-extension allowlist** — a frozen snapshot of a 2016-era ffmpeg's formats. Unknown extensions now warn and defer to ffmpeg (which detects containers from content) instead of raising `ValueError`; formats newer than the snapshot (e.g. `.avif`) now work, and genuinely unreadable inputs fail loudly through the 1.2.1 error-reporting paths. **Behavior change:** writing to an unknown extension raises `RuntimeError` with ffmpeg's diagnostics at write time instead of `ValueError` at construction.

## Security fix
- Binaries (ffprobe/ffmpeg/avconv/mediainfo) resolve **only from absolute PATH entries**. Previously `import skvideo` could execute a stray or malicious `./ffprobe`: via the explicit CWD search entry, and — found by outside review after the first fix — via empty PATH elements (`''`, `':'`, leading/trailing separators, which POSIX treats as the CWD). Relative PATH entries are excluded for the same reason. Regression test sweeps all the malformed-PATH shapes.

Deprecation notes added across README, FAQ, and the API docs. All behavior pinned in `test_deprecations.py` (9 tests).

Externally reviewed (initial verdict "needs work" on the incomplete CWD fix; all three findings addressed and re-verified). Suite: 193 passed / 15 skipped / 0 failed.