### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
-Unreleased
-----------
+1.3.0 (2026-07-04)
+------------------
 
 Internal cleanup (no intended behavior change; all pinned metric
 values verified unchanged)
@@ -23,7 +23,7 @@ values verified unchanged)
 - CI gained a ruff lint gate (pyflakes rules), closing the 2020
   request for flake8 in CI (#136).
 
-Deprecations (removal planned for the release after next)
+Deprecations (removal planned for 1.4.0)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - **The libav/avconv backend is deprecated** (``LibAVReader``,

--- a/README.rst
+++ b/README.rst
@@ -74,10 +74,18 @@ Then check that ``skvideo`` resolves to the expected location::
     print(skvideo.__file__)
 
 
-What's new in 1.2
------------------
+What's new
+----------
 
 scikit-video is actively maintained again.
+
+- **Deprecations and cleanup (1.3.0).** The libav/avconv backend,
+  ``mprobe``/mediainfo, and the hardcoded container-extension allowlist
+  are deprecated (``DeprecationWarning``; removal planned for 1.4.0) --
+  unknown extensions now warn and defer to ffmpeg instead of raising.
+  Binaries are resolved only from absolute PATH entries (never the
+  CWD). Roughly 1,000 lines of dead, vendored, and Python-2-era code
+  removed, with a pyflakes lint gate in CI keeping it that way.
 
 - **Metric accuracy overhaul (1.2.0).** The NIQE, BRISQUE, VIIDEO, and
   Video-BLIINDS implementations were validated against their reference

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -40,7 +40,7 @@ GitHub instead (see https://github.com/scikit-video/scikit-video/releases):
 
 .. code-block:: console
 
-    $ python -m pip install https://github.com/scikit-video/scikit-video/archive/refs/tags/v1.2.1.tar.gz
+    $ python -m pip install https://github.com/scikit-video/scikit-video/archive/refs/tags/v1.3.0.tar.gz
 
 You can verify the module path by importing skvideo and printing the path to the init file
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,8 +8,8 @@
 
 .. code-block:: console
 
-    # v1.2.1 - PyPI upload in progress, install from GitHub:
-    $ python -m pip install https://github.com/scikit-video/scikit-video/archive/refs/tags/v1.2.1.tar.gz
+    # v1.3.0 - PyPI upload in progress, install from GitHub:
+    $ python -m pip install https://github.com/scikit-video/scikit-video/archive/refs/tags/v1.3.0.tar.gz
 
     # Once PyPI is updated (coming soon):
     # python -m pip install scikit-video

--- a/skvideo/__init__.py
+++ b/skvideo/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.1"
+__version__ = "1.3.0"
 
 from .utils import check_output, where
 import os


### PR DESCRIPTION
Version bump + changelog finalization for v1.3.0 (deprecations, cleanup, PATH security fix — see CHANGELOG). Gate: 195 passed / 0 failed, twine check PASSED, clean-install smoke PASSED.